### PR TITLE
Fix de-duplication and use list for worklist

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,3 +1,4 @@
+Hide  modules unnecessary for user like IntToIntMap
 Use user-defined TrieMap as the NodeMap
 Should try to delete items from findRepr because it only ever gets bigger. Deleting items could speed things up
 FindRepr is almost always at depth0, meaning the issue is with 1time in lookup times, the number of times findRepr is called, and the constant factors

--- a/hegg.cabal
+++ b/hegg.cabal
@@ -126,7 +126,7 @@ benchmark hegg-bench
                   tasty-hunit,
                   tasty-quickcheck,
                   tasty-bench >= 0.2  && < 0.4
-  ghc-options:    -O2 -with-rtsopts=-A32m -threaded
+  ghc-options:    -with-rtsopts=-A32m -threaded
 
 Flag vizdot
     Description: Compile 'Data.Equality.Graph.Dot' module to visualize e-graphs

--- a/hegg.cabal
+++ b/hegg.cabal
@@ -75,7 +75,8 @@ library
                       Data.Equality.Analysis,
                       Data.Equality.Saturation.Scheduler,
                       Data.Equality.Saturation.Rewrites,
-                      Data.Equality.Utils
+                      Data.Equality.Utils,
+                      Data.Equality.Utils.SizedList
     if impl(ghc >= 9.2)
         exposed-modules: Data.Equality.Utils.IntToIntMap
 
@@ -95,16 +96,16 @@ library
     default-language: Haskell2010
 
 test-suite hegg-test
-    ghc-options:      -threaded -Wall
+    ghc-options:      -Wall
                       -- -finfo-table-map -fdistinct-constructor-tables
-                      -- -threaded
+                      -threaded
     default-language: Haskell2010
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test
     main-is:          Test.hs
     other-modules:    Invariants, Sym, Lambda, SimpleSym
     other-extensions: OverloadedStrings
-    build-depends:    base >= 4.4 && < 5,
+    build-depends:    base,
                       hegg,
                       containers,
                       deriving-compat  >= 0.6 && < 0.7,
@@ -125,6 +126,7 @@ benchmark hegg-bench
                   tasty-hunit,
                   tasty-quickcheck,
                   tasty-bench >= 0.2  && < 0.4
+  ghc-options:    -O2 -with-rtsopts=-A32m -threaded
 
 Flag vizdot
     Description: Compile 'Data.Equality.Graph.Dot' module to visualize e-graphs

--- a/src/Data/Equality/Extraction.hs
+++ b/src/Data/Equality/Extraction.hs
@@ -73,8 +73,7 @@ extractBest egr cost (flip find egr -> i) =
 
           {-# INLINE f #-}
           f :: (Bool, ClassIdMap (CostWithExpr lang cost)) -> Int -> EClass lang -> (Bool, ClassIdMap (CostWithExpr lang cost))
-          f = \acc@(_, beingUpdated) i' (EClass _ nodes _ _) ->
-
+          f = \acc@(_, beingUpdated) i' EClass{eClassNodes = nodes} ->
                 let
                     currentCost = IM.lookup i' beingUpdated
 

--- a/src/Data/Equality/Extraction.hs
+++ b/src/Data/Equality/Extraction.hs
@@ -109,8 +109,7 @@ extractBest egr cost (flip find egr -> i) =
         expr <- traverse ((`IM.lookup` m) . flip find egr) n
         return $ CostWithExpr (cost ((fst . unCWE) <$> expr), (Fix $ (snd . unCWE) <$> expr))
     {-# INLINE nodeTotalCost #-}
-
-{-# SCC extractBest #-}
+{-# INLINABLE extractBest #-}
 
 -- | A cost function is used to attribute a cost to representations in the
 -- e-graph and to extract the best one.

--- a/src/Data/Equality/Graph.hs
+++ b/src/Data/Equality/Graph.hs
@@ -38,10 +38,11 @@ import Data.Function
 import Data.Bifunctor
 import Data.Containers.ListUtils
 
+import Data.Sequence (Seq(..))
+import qualified Data.Sequence as Seq
+import qualified Data.Foldable as F
 import qualified Data.IntMap.Strict as IM
 import qualified Data.Set    as S
-
-import Data.Equality.Utils.SizedList
 
 import Data.Equality.Graph.Internal
 import Data.Equality.Graph.ReprUnionFind
@@ -84,7 +85,7 @@ add uncanon_e egr =
             -- to the e-class parents the new e-node and its e-class id
             --
             -- And add new e-class to existing e-classes
-            new_parents      = ((new_eclass_id, new_en) |:)
+            new_parents      = ((new_eclass_id, new_en) :<|)
             new_classes      = IM.insert new_eclass_id new_eclass $
                                     foldr  (IM.adjust ((_parents %~ new_parents)))
                                            (classes egr)
@@ -153,7 +154,7 @@ merge a b egr0 =
 
            -- Leader is the class with more parents
            (leader, leader_class, sub, sub_class) =
-               if sizeSL (class_a^._parents) < sizeSL (class_b^._parents)
+               if Seq.length (class_a^._parents) < Seq.length (class_b^._parents)
                   then (b', class_b, a', class_a) -- b is leader
                   else (a', class_a, b', class_b) -- a is leader
 
@@ -174,18 +175,20 @@ merge a b egr0 =
            -- Add all subsumed parents to worklist We can do this instead of
            -- adding the new e-class itself to the worklist because it would end
            -- up adding its parents anyway
-           new_worklist = toListSL (sub_class^._parents) <> (worklist egr0)
+           new_worklist = F.toList (sub_class^._parents) <> worklist egr0
 
            -- If the new_data is different from the classes, the parents of the
            -- class whose data is different from the merged must be put on the
            -- analysisWorklist
            new_analysis_worklist =
-             (if new_data /= (sub_class^._data)
-                 then toListSL (sub_class^._parents)
-                 else mempty) <>
-             (if new_data /= (leader_class^._data)
-                then toListSL (leader_class^._parents)
-                else mempty) <>
+             F.toList (
+               (if new_data /= (sub_class^._data)
+                   then sub_class^._parents
+                   else mempty) <>
+               (if new_data /= (leader_class^._data)
+                  then leader_class^._parents
+                  else mempty)
+             ) <>
              (analysisWorklist egr0)
 
            -- ROMES:TODO: The code that makes the -1 * cos test pass when some other things are tweaked
@@ -217,7 +220,7 @@ rebuild (EGraph uf cls mm wl awl) =
   -- empty worklists
   -- repair deduplicated e-classes
   let
-    emptiedEgr = (EGraph uf cls mm mempty mempty)
+    emptiedEgr = EGraph uf cls mm mempty mempty
     wl'   = nubOrd $ bimap (`find` emptiedEgr) (`canonicalize` emptiedEgr) <$> wl
     awl'  = nubOrd $ bimap (`find` emptiedEgr) (`canonicalize` emptiedEgr) <$> awl
     egr'  = foldr repair emptiedEgr wl'
@@ -255,7 +258,7 @@ repairAnal (repair_id, node) egr =
     if c^._data /= new_data
         -- Merge result is different from original class data, update class
         -- with new_data
-       then egr { analysisWorklist = toListSL (c^._parents) <> analysisWorklist egr
+       then egr { analysisWorklist = F.toList (c^._parents) <> analysisWorklist egr
                 }
                 & _class repair_id._data .~ new_data
                 & modifyA repair_id

--- a/src/Data/Equality/Graph/Classes.hs
+++ b/src/Data/Equality/Graph/Classes.hs
@@ -8,7 +8,6 @@ module Data.Equality.Graph.Classes
     , module Data.Equality.Graph.Classes.Id
     ) where
 
-import qualified Data.Sequence  as Seq
 import qualified Data.Set as S
 
 import Data.Functor.Classes
@@ -28,7 +27,7 @@ data EClass l = EClass
     { eClassId      :: {-# UNPACK #-} !ClassId -- ^ E-class identifier
     , eClassNodes   :: !(S.Set (ENode l))      -- ^ E-nodes in this class
     , eClassData    :: Domain l                -- ^ The analysis data associated with this eclass.
-    , eClassParents :: !(Seq.Seq (ClassId, ENode l))   -- ^ E-nodes which are parents of this e-class and their corresponding e-class ids.
+    , eClassParents :: !(S.Set (ClassId, ENode l))   -- ^ E-nodes which are parents of this e-class and their corresponding e-class ids.
     }
 
 instance (Show (Domain l), Show1 l) => Show (EClass l) where

--- a/src/Data/Equality/Graph/Classes.hs
+++ b/src/Data/Equality/Graph/Classes.hs
@@ -8,14 +8,13 @@ module Data.Equality.Graph.Classes
     , module Data.Equality.Graph.Classes.Id
     ) where
 
+import qualified Data.Sequence  as Seq
 import qualified Data.Set as S
 
 import Data.Functor.Classes
 
 import Data.Equality.Graph.Classes.Id
 import Data.Equality.Graph.Nodes
-
-import Data.Equality.Utils.SizedList
 
 import Data.Equality.Analysis
 
@@ -29,9 +28,9 @@ data EClass l = EClass
     { eClassId      :: {-# UNPACK #-} !ClassId -- ^ E-class identifier
     , eClassNodes   :: !(S.Set (ENode l))      -- ^ E-nodes in this class
     , eClassData    :: Domain l                -- ^ The analysis data associated with this eclass.
-    , eClassParents :: !(SList (ClassId, ENode l))   -- ^ E-nodes which are parents of this e-class and their corresponding e-class ids.
+    , eClassParents :: !(Seq.Seq (ClassId, ENode l))   -- ^ E-nodes which are parents of this e-class and their corresponding e-class ids.
     }
 
 instance (Show (Domain l), Show1 l) => Show (EClass l) where
-    show (EClass a b d (SList c _)) = "Id: " <> show a <> "\nNodes: " <> show b <> "\nParents: " <> show c <> "\nData: " <> show d
+    show (EClass a b d c) = "Id: " <> show a <> "\nNodes: " <> show b <> "\nParents: " <> show c <> "\nData: " <> show d
 

--- a/src/Data/Equality/Graph/Classes.hs
+++ b/src/Data/Equality/Graph/Classes.hs
@@ -15,6 +15,8 @@ import Data.Functor.Classes
 import Data.Equality.Graph.Classes.Id
 import Data.Equality.Graph.Nodes
 
+import Data.Equality.Utils.SizedList
+
 import Data.Equality.Analysis
 
 -- | An e-class (an equivalence class of terms) of a language @l@.
@@ -27,9 +29,9 @@ data EClass l = EClass
     { eClassId      :: {-# UNPACK #-} !ClassId -- ^ E-class identifier
     , eClassNodes   :: !(S.Set (ENode l))      -- ^ E-nodes in this class
     , eClassData    :: Domain l                -- ^ The analysis data associated with this eclass.
-    , eClassParents :: !(NodeMap l ClassId)    -- ^ E-nodes which are parents of this e-class and their corresponding e-class ids. We found a mapping from nodes to e-class ids a better representation than @[(ENode l, ClassId)]@, and we get de-duplication built-in.
+    , eClassParents :: !(SList (ClassId, ENode l))   -- ^ E-nodes which are parents of this e-class and their corresponding e-class ids.
     }
 
 instance (Show (Domain l), Show1 l) => Show (EClass l) where
-    show (EClass a b d c) = "Id: " <> show a <> "\nNodes: " <> show b <> "\nParents: " <> show c <> "\nData: " <> show d
+    show (EClass a b d (SList c _)) = "Id: " <> show a <> "\nNodes: " <> show b <> "\nParents: " <> show c <> "\nData: " <> show d
 

--- a/src/Data/Equality/Graph/Classes.hs
+++ b/src/Data/Equality/Graph/Classes.hs
@@ -15,6 +15,8 @@ import Data.Functor.Classes
 import Data.Equality.Graph.Classes.Id
 import Data.Equality.Graph.Nodes
 
+import Data.Equality.Utils.SizedList
+
 import Data.Equality.Analysis
 
 -- | An e-class (an equivalence class of terms) of a language @l@.
@@ -27,9 +29,9 @@ data EClass l = EClass
     { eClassId      :: {-# UNPACK #-} !ClassId -- ^ E-class identifier
     , eClassNodes   :: !(S.Set (ENode l))      -- ^ E-nodes in this class
     , eClassData    :: Domain l                -- ^ The analysis data associated with this eclass.
-    , eClassParents :: !(S.Set (ClassId, ENode l))   -- ^ E-nodes which are parents of this e-class and their corresponding e-class ids.
+    , eClassParents :: !(SList (ClassId, ENode l))   -- ^ E-nodes which are parents of this e-class and their corresponding e-class ids.
     }
 
 instance (Show (Domain l), Show1 l) => Show (EClass l) where
-    show (EClass a b d c) = "Id: " <> show a <> "\nNodes: " <> show b <> "\nParents: " <> show c <> "\nData: " <> show d
+    show (EClass a b d (SList c _)) = "Id: " <> show a <> "\nNodes: " <> show b <> "\nParents: " <> show c <> "\nData: " <> show d
 

--- a/src/Data/Equality/Graph/Internal.hs
+++ b/src/Data/Equality/Graph/Internal.hs
@@ -7,6 +7,7 @@
 module Data.Equality.Graph.Internal where
 
 import Data.Functor.Classes
+import qualified Data.Set as S
 
 import Data.Equality.Graph.ReprUnionFind
 import Data.Equality.Graph.Classes
@@ -23,7 +24,7 @@ data EGraph l = EGraph
     , classes   :: !(ClassIdMap (EClass l)) -- ^ Map canonical e-class ids to their e-classes
     , memo      :: !(Memo l)                -- ^ Hashcons maps all canonical e-nodes to their e-class ids
     , worklist  :: !(Worklist l)            -- ^ Worklist of e-class ids that need to be upward merged
-    , analysisWorklist :: !(Worklist l)     -- ^ Like 'worklist' but for analysis repairing
+    , analysisWorklist :: !(S.Set (ClassId, ENode l))     -- ^ Like 'worklist' but for analysis repairing
     }
 
 -- | The hashcons 𝐻  is a map from e-nodes to e-class ids

--- a/src/Data/Equality/Graph/Internal.hs
+++ b/src/Data/Equality/Graph/Internal.hs
@@ -30,7 +30,7 @@ data EGraph l = EGraph
 type Memo l = NodeMap l ClassId
 
 -- | Maintained worklist of e-class ids that need to be “upward merged”
-type Worklist l = NodeMap l ClassId
+type Worklist l = [(ClassId, ENode l)]
 
 instance (Show (Domain l), Show1 l) => Show (EGraph l) where
     show (EGraph a b c d e) =

--- a/src/Data/Equality/Graph/Internal.hs
+++ b/src/Data/Equality/Graph/Internal.hs
@@ -7,7 +7,6 @@
 module Data.Equality.Graph.Internal where
 
 import Data.Functor.Classes
-import qualified Data.Set as S
 
 import Data.Equality.Graph.ReprUnionFind
 import Data.Equality.Graph.Classes
@@ -24,7 +23,7 @@ data EGraph l = EGraph
     , classes   :: !(ClassIdMap (EClass l)) -- ^ Map canonical e-class ids to their e-classes
     , memo      :: !(Memo l)                -- ^ Hashcons maps all canonical e-nodes to their e-class ids
     , worklist  :: !(Worklist l)            -- ^ Worklist of e-class ids that need to be upward merged
-    , analysisWorklist :: !(S.Set (ClassId, ENode l))     -- ^ Like 'worklist' but for analysis repairing
+    , analysisWorklist :: !(Worklist l)     -- ^ Like 'worklist' but for analysis repairing
     }
 
 -- | The hashcons 𝐻  is a map from e-nodes to e-class ids

--- a/src/Data/Equality/Graph/Lens.hs
+++ b/src/Data/Equality/Graph/Lens.hs
@@ -8,7 +8,6 @@
  -}
 module Data.Equality.Graph.Lens where
 
-import qualified Data.Sequence  as Seq
 import qualified Data.IntMap.Strict as IM
 import qualified Data.Set as S
 
@@ -62,7 +61,7 @@ _data afa EClass{..} = (\d1 -> EClass eClassId eClassNodes d1 eClassParents) <$>
 {-# INLINE _data #-}
 
 -- | Lens for the parent e-classes of an e-class
-_parents :: Lens' (EClass l) (Seq.Seq (ClassId, ENode l))
+_parents :: Lens' (EClass l) (S.Set (ClassId, ENode l))
 _parents afa EClass{..} = (\ps -> EClass eClassId eClassNodes eClassData ps) <$> afa eClassParents
 {-# INLINE _parents #-}
 

--- a/src/Data/Equality/Graph/Lens.hs
+++ b/src/Data/Equality/Graph/Lens.hs
@@ -8,13 +8,13 @@
  -}
 module Data.Equality.Graph.Lens where
 
+import qualified Data.Sequence  as Seq
 import qualified Data.IntMap.Strict as IM
 import qualified Data.Set as S
 
 import Data.Functor.Identity
 import Data.Functor.Const
 
-import Data.Equality.Utils.SizedList
 import Data.Equality.Graph.Internal
 import Data.Equality.Graph.Classes.Id
 import Data.Equality.Graph.Nodes
@@ -62,7 +62,7 @@ _data afa EClass{..} = (\d1 -> EClass eClassId eClassNodes d1 eClassParents) <$>
 {-# INLINE _data #-}
 
 -- | Lens for the parent e-classes of an e-class
-_parents :: Lens' (EClass l) (SList (ClassId, ENode l))
+_parents :: Lens' (EClass l) (Seq.Seq (ClassId, ENode l))
 _parents afa EClass{..} = (\ps -> EClass eClassId eClassNodes eClassData ps) <$> afa eClassParents
 {-# INLINE _parents #-}
 

--- a/src/Data/Equality/Graph/Lens.hs
+++ b/src/Data/Equality/Graph/Lens.hs
@@ -14,6 +14,7 @@ import qualified Data.Set as S
 import Data.Functor.Identity
 import Data.Functor.Const
 
+import Data.Equality.Utils.SizedList
 import Data.Equality.Graph.Internal
 import Data.Equality.Graph.Classes.Id
 import Data.Equality.Graph.Nodes
@@ -61,8 +62,8 @@ _data afa EClass{..} = (\d1 -> EClass eClassId eClassNodes d1 eClassParents) <$>
 {-# INLINE _data #-}
 
 -- | Lens for the parent e-classes of an e-class
-_parents :: Lens' (EClass l) (NodeMap l ClassId)
-_parents afa EClass{..} = EClass eClassId eClassNodes eClassData <$> afa eClassParents
+_parents :: Lens' (EClass l) (SList (ClassId, ENode l))
+_parents afa EClass{..} = (\ps -> EClass eClassId eClassNodes eClassData ps) <$> afa eClassParents
 {-# INLINE _parents #-}
 
 -- | Lens for the e-nodes in an e-class

--- a/src/Data/Equality/Graph/Lens.hs
+++ b/src/Data/Equality/Graph/Lens.hs
@@ -14,6 +14,7 @@ import qualified Data.Set as S
 import Data.Functor.Identity
 import Data.Functor.Const
 
+import Data.Equality.Utils.SizedList
 import Data.Equality.Graph.Internal
 import Data.Equality.Graph.Classes.Id
 import Data.Equality.Graph.Nodes
@@ -61,7 +62,7 @@ _data afa EClass{..} = (\d1 -> EClass eClassId eClassNodes d1 eClassParents) <$>
 {-# INLINE _data #-}
 
 -- | Lens for the parent e-classes of an e-class
-_parents :: Lens' (EClass l) (S.Set (ClassId, ENode l))
+_parents :: Lens' (EClass l) (SList (ClassId, ENode l))
 _parents afa EClass{..} = (\ps -> EClass eClassId eClassNodes eClassData ps) <$> afa eClassParents
 {-# INLINE _parents #-}
 

--- a/src/Data/Equality/Graph/Nodes.hs
+++ b/src/Data/Equality/Graph/Nodes.hs
@@ -37,7 +37,7 @@ newtype ENode l = Node { unNode :: l ClassId }
 -- | Get the children e-class ids of an e-node
 children :: Traversable l => ENode l -> [ClassId]
 children = toList . unNode
-{-# SCC children #-}
+{-# INLINE children #-}
 
 -- * Operator
 
@@ -48,7 +48,7 @@ newtype Operator l = Operator { unOperator :: l () }
 -- | Get the operator (function symbol) of an e-node
 operator :: Traversable l => ENode l -> Operator l
 operator = Operator . void . unNode
-{-# SCC operator #-}
+{-# INLINE operator #-}
 
 instance Eq1 l => (Eq (ENode l)) where
     (==) (Node a) (Node b) = liftEq (==) a b

--- a/src/Data/Equality/Graph/ReprUnionFind.hs
+++ b/src/Data/Equality/Graph/ReprUnionFind.hs
@@ -75,7 +75,6 @@ makeNewSet (RUF im si) = ((I# si), RUF (IIM.insert si 0# im) ((si +# 1#)))
 #else
 makeNewSet (RUF im si) = (si, RUF (IIM.insert si 0 im) (si + 1))
 #endif
-{-# SCC makeNewSet #-}
 
 -- | Union operation of the union find.
 --
@@ -94,21 +93,20 @@ unionSets a b (RUF im si) = (a, RUF (IIM.insert b a im) si)
     -- represented_by_b = hc IM.! b
     -- -- Overwrite previous id of b (which should be 0#) with new representative (a)
     -- -- AND "rebuild" all nodes represented by b by making them represented directly by a
-    -- new_im = {-# SCC "rebuild_im" #-} IIM.unliftedFoldr (\(I# x) -> IIM.insert x a#) (IIM.insert b# a# im) represented_by_b
-    -- new_hc = {-# SCC "adjust_hc" #-} IM.adjust ((b:) . (represented_by_b <>)) a (IM.delete b hc)
-{-# SCC unionSets #-}
+    -- new_im = IIM.unliftedFoldr (\(I# x) -> IIM.insert x a#) (IIM.insert b# a# im) represented_by_b
+    -- new_hc = IM.adjust ((b:) . (represented_by_b <>)) a (IM.delete b hc)
 
 -- | Find the canonical representation of an e-class id
 findRepr :: ClassId -> ReprUnionFind
          -> ClassId -- ^ The found canonical representation
 #if __GLASGOW_HASKELL__ >= 902
 findRepr v@(I# v#) (RUF m s) =
-  case {-# SCC "findRepr_TAKE" #-} m IIM.! v# of
+  case m IIM.! v# of
     0# -> v
     x  -> findRepr (I# x) (RUF m s)
 #else
 findRepr v (RUF m s) =
-  case {-# SCC "findRepr_TAKE" #-} m IIM.! v of
+  case m IIM.! v of
     0 -> v
     x -> findRepr x (RUF m s)
 #endif
@@ -121,7 +119,6 @@ findRepr v (RUF m s) =
 --
 -- When using the ad-hoc path compression in `unionSets`, the depth of
 -- recursion never even goes above 1!
-{-# SCC findRepr #-}
 
 
 -- {-# RULES

--- a/src/Data/Equality/Matching.hs
+++ b/src/Data/Equality/Matching.hs
@@ -79,7 +79,6 @@ eGraphToDatabase egr = foldrWithKeyNM' addENodeToDB (DB mempty) (egr^._memo)
         -- ROMES:TODO map find
         -- Insert or create a relation R_f(i1,i2,...,in) for lang in which 
         DB $ M.alter (Just . populate (classid:children enode)) (operator enode) m
-    {-# SCC addENodeToDB #-}
 
     -- Populate or create a triemap given the population D_x (ClassIds)
     -- Insert remaining ids population doesn't exist, recursively merge tries with remaining ids
@@ -90,8 +89,7 @@ eGraphToDatabase egr = foldrWithKeyNM' addENodeToDB (DB mempty) (egr^._memo)
     -- If trie map entry already exists, populate the existing map with the remaining ids
     populate []     (Just it)              = it
     populate (x:xs) (Just (MkIntTrie k m)) = MkIntTrie (x `IS.insert` k) $ IM.alter (Just . populate xs) x m
-    {-# SCC populate #-}
-{-# SCC eGraphToDatabase #-}
+{-# INLINABLE eGraphToDatabase #-}
 
 
 -- * Database related internals
@@ -135,4 +133,4 @@ compileToQuery pa@(NonVariablePattern _) =
         vars :: Foldable lang => Pattern lang -> [Var]
         vars (VariablePattern x) = [x]
         vars (NonVariablePattern p) = nubInt $ join $ map vars $ toList p
-{-# SCC compileToQuery #-}
+{-# INLINABLE compileToQuery #-}

--- a/src/Data/Equality/Saturation.hs
+++ b/src/Data/Equality/Saturation.hs
@@ -187,5 +187,5 @@ equalitySaturation' _ expr rewrites cost = egraph $ do
                     Nothing -> error "impossible: couldn't find v in subst?"
                     Just i  -> return i
             NonVariablePattern p -> reprPat subst p
-{-# SCC equalitySaturation' #-}
+{-# INLINABLE equalitySaturation' #-}
 

--- a/src/Data/Equality/Saturation/Scheduler.hs
+++ b/src/Data/Equality/Saturation/Scheduler.hs
@@ -79,7 +79,6 @@ instance Scheduler BackoffScheduler where
           updateBans = \case
             Nothing -> Just (BSS (i + ban_length) 1)
             Just (BSS _ n)  -> Just (BSS (i + ban_length) (n+1))
-    {-# SCC updateStats #-}
 
     isBanned i s = i < bannedUntil s
 

--- a/src/Data/Equality/Utils/IntToIntMap.hs
+++ b/src/Data/Equality/Utils/IntToIntMap.hs
@@ -78,7 +78,6 @@ find' k (Bin _p m l r)
   | otherwise = find' k r
 find' k (Tip kx x) | isTrue# (k `eqWord#` kx) = x
 find' _ _ = error ("IntMap.!: key ___ is not an element of the map")
-{-# SCC find' #-}
 
 -- * Other stuff taken from IntMap
 

--- a/src/Data/Equality/Utils/SizedList.hs
+++ b/src/Data/Equality/Utils/SizedList.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE TypeFamilies #-}
+{-|
+   Util: A list with a O(1) size function
+ -}
+module Data.Equality.Utils.SizedList where
+
+import qualified Data.List
+import GHC.Exts
+import Data.Foldable
+
+-- | A list with O(1) size access and O(1) conversion to normal list
+data SList a = SList ![a] {-# UNPACK #-} !Int
+  deriving Traversable
+
+instance Semigroup (SList a) where
+  (<>) (SList a i) (SList b j) = SList (a <> b) (i+j)
+  {-# INLINE (<>) #-}
+
+instance Monoid (SList a) where
+  mempty = SList mempty 0
+  {-# INLINE mempty #-}
+
+instance Functor SList where
+  fmap f (SList a i) = SList (fmap f a) i
+  {-# INLINE fmap #-}
+
+instance Foldable SList where
+  fold       ( SList l _) = fold l
+  foldMap f  ( SList l _) = foldMap f l
+  foldMap' f ( SList l _) = foldMap' f l
+  foldr f b  ( SList l _) = foldr f b l
+  foldr' f b ( SList l _) = foldr' f b l
+  foldl f b  ( SList l _) = foldl f b l
+  foldl' f b ( SList l _) = foldl' f b l
+  foldr1 f   ( SList l _) = foldr1 f l
+  foldl1 f   ( SList l _) = foldl1 f l
+  toList     ( SList l _) = l
+  null       ( SList l _) = Data.List.null l
+  length     ( SList _ i) = i
+  elem x     ( SList l _) = x `elem` l
+  maximum    ( SList l _) = maximum l
+  minimum    ( SList l _) = minimum l
+  sum        ( SList l _) = sum l
+  product    ( SList l _) = product l
+
+instance IsList (SList a) where
+  type Item (SList a) = a
+  fromList l          = SList l (length l)
+  fromListN i l       = SList l i
+  toList (SList l _)  = l
+
+-- | Prepend an item to the list in O(1)
+(|:) :: a -> SList a -> SList a
+(|:) a (SList l i) = SList (a:l) (i+1)
+{-# INLINE (|:) #-}
+
+-- | Make a normal list from the sized list in O(1)
+toListSL :: SList a -> [a]
+toListSL (SList l _) = l
+{-# INLINE toListSL #-}
+
+-- | Get the size of the list in O(1)
+sizeSL :: SList a -> Int
+sizeSL (SList _ i) = i
+{-# INLINE sizeSL #-}

--- a/test/Invariants.hs
+++ b/test/Invariants.hs
@@ -127,7 +127,7 @@ hashConsInvariant eg =
     all f (IM.toList (eg^._classes))
     where
       -- e-node 𝑛 ∈ 𝑀 [𝑎] ⇐⇒ 𝐻 [canonicalize(𝑛)] = find(𝑎)
-      f (i, EClass _ nodes _ _) = all g nodes
+      f (i, EClass{eClassNodes=nodes}) = all g nodes
         where
           g en = case lookupNM (canonicalize en eg) (eg^._memo) of
             Nothing -> error "how can we not find canonical thing in map? :)" -- False

--- a/test/Sym.hs
+++ b/test/Sym.hs
@@ -112,11 +112,9 @@ instance Fractional (Pattern Expr) where
 instance Analysis Expr where
     type Domain Expr = Maybe Double
 
-    {-# SCC makeA #-}
     makeA (Node e) egr = evalConstant ((\c -> egr^._class c._data) <$> e)
 
     -- joinA = (<|>)
-    {-# SCC joinA #-}
     joinA ma mb = do
         a <- ma
         b <- mb
@@ -126,7 +124,6 @@ instance Analysis Expr where
         !_ <- unless (a == b || (a == 0 && b == (-0)) || (a == (-0) && b == 0)) (error "Merged non-equal constants!")
         return a
 
-    {-# SCC modifyA #-}
     modifyA i egr =
         case egr ^._class i._data of
           Nothing -> egr


### PR DESCRIPTION
Closes #2 

We were previously using a Map for the worklist, and the deduplication
step wasn't being done correctly. This came to be from historic changes
to the representations that ultimately led to deduplication being
overlooked.


The performance significantly improves with these changes.

I think the classes parents representation was also improved. We use `SList` instead of just list because we need a O(1) size function