### PR TITLE
Make the Data.Equality.Graph.Dot module compile again

### DIFF
--- a/.github/workflows/graphviz.yml
+++ b/.github/workflows/graphviz.yml
@@ -1,0 +1,21 @@
+name: Build GraphViz Module
+on:
+    - push
+    - pull_request
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        ghc: ['8.10.7', '9.2.7', '9.4.5', '9.6.2']
+        cabal: ['3.0.0.0']
+        os: [ubuntu-latest]
+    name: Build GraphViz Module ${{ matrix.ghc }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Haskell
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
+      - run: cabal build -f vizdot

--- a/.github/workflows/graphviz.yml
+++ b/.github/workflows/graphviz.yml
@@ -1,7 +1,13 @@
 name: Build GraphViz Module
 on:
-    - push
-    - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -18,4 +24,22 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
-      - run: cabal build -f vizdot
+      - name: Configure the build plan
+        run: |
+            cabal update
+            cabal build -f vizdot --dry-run
+          # cabal build --dry-run creates dist-newstyle/cache/plan.json
+          # Keep a watch on this `cabal-3.9 build --dry-run` bug:
+          # https://github.com/haskell/cabal/issues/8706
+      - name: Read the Cabal cache
+        uses: actions/cache@v3
+        with:
+            path: |
+              ~/.cabal/store
+              dist-newstyle
+            key: |
+              cabal-cache-ghc-${{ matrix.ghc }}-cabal-${{ matrix.cabal }}-${{ hashFiles('**/plan.json') }}
+            restore-keys: |
+              cabal-cache-ghc-${{ matrix.ghc }}-cabal-${{ matrix.cabal }}-
+      - name: Build the Data.Equality.Graph.Dot module
+        run: cabal build -f vizdot

--- a/hegg.cabal
+++ b/hegg.cabal
@@ -104,7 +104,8 @@ library
                       transformers >= 0.4 && < 0.7,
                       containers   >= 0.4 && < 0.7
     if flag(vizdot)
-        build-depends: graphviz >= 2999.6 && < 2999.7
+        build-depends: graphviz >= 2999.20 && < 2999.21,
+                       text
     hs-source-dirs:   src
     default-language: Haskell2010
 

--- a/src/Data/Equality/Graph/Dot.hs
+++ b/src/Data/Equality/Graph/Dot.hs
@@ -24,10 +24,7 @@ import Data.GraphViz.Attributes (style, dotted, textLabel)
 import Data.GraphViz.Attributes.Complete
 
 import Data.Equality.Graph
-import Data.Equality.Graph.Nodes
-import Data.Equality.Graph.Classes
 import Data.Equality.Graph.Internal
-import Data.Equality.Language
 
 txt :: Show a => a -> Text
 txt = pack . show

--- a/src/Data/Equality/Graph/Dot.hs
+++ b/src/Data/Equality/Graph/Dot.hs
@@ -26,7 +26,6 @@ import Data.GraphViz.Attributes.Complete
 import Data.Equality.Saturation
 import Data.Equality.Graph
 import Data.Equality.Matching
-import Database
 
 txt = pack . show
 


### PR DESCRIPTION
I haven't looked at whether the generated dot files are sensible, i.e. this doesn't solve #26 yet, I only took care that the module compiles again.
More concretely:
- The bounds on the Graphviz dependency fixed a very ancient version of that library. I don't know whether there was a specific reason for that, but I didn't get it to compile on modern GHCs.
- Adapted the imports and the constructors to the current state of the data types.
- Added additional CI which tests that you can build the `Data.Equality.Graph.Dot` module

I don't know if I have enough time before our meeting to implement improved dot file generation, I have to pack tomorrow :)