### PR TITLE
Invariants: fix incomplete pattern match warning

### DIFF
--- a/test/Invariants.hs
+++ b/test/Invariants.hs
@@ -64,10 +64,10 @@ testCompileToQuery p = case fst $ compileToQuery p of
                          -- Handle special case for selectAll queries...
                          SelectAllQuery x -> [x] == vars p && numNonVarPatterns p == 0
                          q@(Query _ atoms)
-                           | [] <- queryHeadVars q   -> False
                            | _:xs <- queryHeadVars q ->
                                L.sort xs == L.sort (vars p)
                                  && length atoms == numNonVarPatterns p
+                           | otherwise -> False
     where
         numNonVarPatterns :: Foldable lang => Pattern lang -> Int
         numNonVarPatterns (VariablePattern _) = 0


### PR DESCRIPTION
9.4.x seems to flag an incomplete pattern match where other ghc versions don't. Replacing the initial pattern guard match against an empty list with a final otherwise pattern guard clause silences it relatively intuitively. The semantics should be preserved as the use of the pattern guard match in testCompileToQuery is equivalent to case.

Compile-tested against 9.8.1, 9.6.2, 9.4.5, 9.2.8 and 8.10.7.