### PR TITLE
Allow equality saturation to be applied to type-indexed expressions

### DIFF
--- a/hegg.cabal
+++ b/hegg.cabal
@@ -77,18 +77,30 @@ library
                       Data.Equality.Graph.Nodes,
                       Data.Equality.Graph.Lens,
                       Data.Equality.Graph.Monad,
+                      Data.Equality.Graph.Indexed,
+                      Data.Equality.Graph.Monad.Indexed,
                       Data.Equality.Matching,
                       Data.Equality.Matching.Database,
                       Data.Equality.Matching.Pattern,
+                      Data.Equality.Matching.Pattern.Indexed,
+                      Data.Equality.Matching.Indexed,
                       Data.Equality.Saturation,
                       Data.Equality.Extraction,
+                      Data.Equality.Extraction.Indexed,
                       Data.Equality.Language,
+                      Data.Equality.Language.Indexed,
                       Data.Equality.Analysis,
+                      Data.Equality.Analysis.Indexed,
                       Data.Equality.Analysis.Monadic,
                       Data.Equality.Saturation.Scheduler,
                       Data.Equality.Saturation.Rewrites,
+                      Data.Equality.Saturation.Rewrites.Indexed,
+                      Data.Equality.Saturation.Indexed,
                       Data.Equality.Utils,
-                      Data.Equality.Utils.SizedList
+                      Data.Equality.Utils.SizedList,
+                      Data.Equality.Utils.Singleton,
+                      Data.Equality.Utils.HList,
+                      Data.Equality.Utils.Untyped
     if impl(ghc >= 9.2)
         exposed-modules: Data.Equality.Utils.IntToIntMap
 
@@ -118,7 +130,7 @@ test-suite hegg-test
     hs-source-dirs:   test
     main-is:          Test.hs
     other-modules:    Invariants, Sym, Lambda, SimpleSym,
-                      T1, T2, T3, T32
+                      T1, T2, T3, T32, Singleton, Indexed, SymExpr
     if flag(vizdot)
         other-modules: VizDot
         cpp-options:  -DVIZDOT

--- a/src/Data/Equality/Analysis.hs
+++ b/src/Data/Equality/Analysis.hs
@@ -100,7 +100,7 @@ class Eq domain => Analysis domain (l :: Type -> Type) where
 
 -- | The simplest analysis that defines the domain to be () and does nothing
 -- otherwise
-instance forall l. Analysis () l where
+instance {-# INCOHERENT #-} forall l. Analysis () l where
   makeA _ = ()
   joinA = (<>)
 
@@ -126,7 +126,7 @@ instance forall l. Analysis () l where
 --
 -- Note: there are weaker (or at least different) criteria for this instance to
 -- be well behaved.
-instance (Language l, Analysis a l, Analysis b l) => Analysis (a, b) l where
+instance {-# INCOHERENT #-} (Language l, Analysis a l, Analysis b l) => Analysis (a, b) l where
 
   makeA :: l (a, b) -> (a, b)
   makeA g = (makeA @a (fst <$> g), makeA @b (snd <$> g))

--- a/src/Data/Equality/Analysis/Indexed.hs
+++ b/src/Data/Equality/Analysis/Indexed.hs
@@ -1,0 +1,133 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-|
+Module      : Data.Equality.Analysis.Indexed
+Description : E-class analysis for type-indexed expressions
+Copyright   : (c) 2024
+License     : BSD-3-Clause
+
+This module provides the 'AnalysisI' typeclass for type-indexed expressions,
+analogous to the 'Analysis' typeclass but preserving type index information.
+
+The key insight is that 'makeAI' receives the full type-indexed expression
+with its type indices, allowing type-aware analysis computation.
+
+Example:
+
+@
+-- Constant folding analysis that respects types
+instance AnalysisI (Maybe Int) TExpr where
+    makeAI :: TExpr cods dom (Maybe Int) -> Maybe Int
+    makeAI (TConst n) = Just n
+    makeAI (TAdd mx my) = liftA2 (+) mx my
+    makeAI _ = Nothing
+
+    joinAI = (<|>)
+@
+-}
+module Data.Equality.Analysis.Indexed
+    ( -- * Type-indexed analysis
+      AnalysisI(..)
+    ) where
+
+import Data.Kind (Type)
+import Data.Proxy
+
+import Data.Equality.Graph.Classes.Id
+import Data.Equality.Graph.Internal (EGraph)
+import Data.Equality.Utils.Singleton
+import Data.Equality.Utils.Untyped
+import Data.Equality.Analysis
+import Data.Equality.Language.Indexed
+
+-- | An e-class analysis with domain @domain@ defined for a type-indexed
+-- language @l@.
+--
+-- This is analogous to 'Analysis' but preserves type index information,
+-- allowing analysis to be computed based on the specific type of each
+-- expression.
+--
+-- The @domain@ is the type of the analysis data stored in each e-class.
+class Eq domain => AnalysisI domain (l :: k -> Type -> Type) where
+
+    -- | When a new e-node is added into a new, singleton e-class, construct
+    -- a new value of the domain to be associated with the new e-class.
+    --
+    -- Unlike 'makeA', this function receives the full type-indexed expression
+    -- including type index @dom@, allowing type-aware analysis.
+    --
+    -- The argument is the e-node term populated with its children data.
+    makeAI :: forall dom. SingI dom
+           => l dom domain -> domain
+
+    -- | When e-classes c1 and c2 are being merged into c, join d_c1 and
+    -- d_c2 into a new value d_c to be associated with the new e-class c.
+    --
+    -- The 'Proxy' parameter is used to disambiguate which language this
+    -- analysis is for, since 'joinAI' doesn't otherwise mention @l@.
+    joinAI :: Proxy l -> domain -> domain -> domain
+
+    -- | Optionally modify the e-class c (based on d_c), typically by adding
+    -- an e-node to c.
+    --
+    -- This operates on the erased e-graph since modifications may need to
+    -- add new expressions of potentially different types.
+    --
+    -- Modify should be idempotent if no other changes occur to the e-class,
+    -- i.e., @modifyAI(modifyAI(c)) = modifyAI(c)@.
+    --
+    -- The 'Proxy' parameter disambiguates the language type.
+    modifyAI :: Proxy l
+             -> ClassId
+             -> EGraph domain (ErasedLang l)
+             -> EGraph domain (ErasedLang l)
+    modifyAI _ _ = id
+    {-# INLINE modifyAI #-}
+
+-- | The simplest analysis for type-indexed languages that defines the domain
+-- to be @()@ and does nothing otherwise.
+instance forall k (l :: k -> Type -> Type). AnalysisI () l where
+    makeAI _ = ()
+    joinAI _ = (<>)
+    {-# INLINE makeAI #-}
+    {-# INLINE joinAI #-}
+
+-- | Bridge instance that allows 'AnalysisI' to work with the standard
+-- e-graph machinery through 'ErasedLang'.
+--
+-- This instance delegates to 'AnalysisI' methods, unwrapping the erased
+-- expression to access the underlying type-indexed expression.
+--
+-- NOTE: This is technically an orphan instance (neither the typeclass nor
+-- the type is defined in this module), but it's the most logical place for it
+-- since it bridges between AnalysisI and Analysis. The orphan warning is
+-- suppressed via OPTIONS_GHC pragma at the top of this module.
+instance {-# OVERLAPPING #-} (LanguageI l, SOrd k, AnalysisI domain l)
+         => Analysis domain (ErasedLang (l :: k -> Type -> Type)) where
+
+    makeA :: ErasedLang l domain -> domain
+    makeA (ErasedLang (Untyped x)) = makeAI x
+    {-# INLINE makeA #-}
+
+    joinA :: domain -> domain -> domain
+    joinA = joinAI (Proxy :: Proxy l)
+    {-# INLINE joinA #-}
+
+    modifyA :: ClassId -> EGraph domain (ErasedLang l) -> EGraph domain (ErasedLang l)
+    modifyA = modifyAI (Proxy :: Proxy l)
+    {-# INLINE modifyA #-}

--- a/src/Data/Equality/Extraction/Indexed.hs
+++ b/src/Data/Equality/Extraction/Indexed.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-|
+Module      : Data.Equality.Extraction.Indexed
+Description : Extraction from type-indexed e-graphs
+Copyright   : (c) 2024
+License     : BSD-3-Clause
+
+This module provides extraction functions for type-indexed e-graphs.
+
+Since equality saturation may combine expressions of different types
+within an equivalence class, extraction returns the type-erased
+representation. Users can then attempt to reconstruct typed expressions
+from the erased form if needed.
+
+Example:
+
+@
+-- Extract best expression from indexed e-graph
+let best = extractBestI egraphI costFn classId
+
+-- The result is in erased form: Fix (ErasedLang TExpr)
+@
+-}
+module Data.Equality.Extraction.Indexed
+    ( -- * Extraction
+      extractBestI
+      -- * Cost functions
+    , CostFunction
+    , depthCostI
+      -- * Re-exports
+    , Fix(..)
+    , ClassId
+    ) where
+
+import Data.Kind (Type)
+
+import Data.Equality.Utils (Fix(..))
+import Data.Equality.Graph (ClassId)
+import Data.Equality.Graph.Indexed
+import Data.Equality.Extraction (CostFunction, extractBest, depthCost)
+import Data.Equality.Language.Indexed
+import Data.Equality.Utils.Singleton
+import Data.Equality.Utils.Untyped (ErasedLang)
+
+-- | Extract the best expression from an equivalence class in an indexed e-graph.
+--
+-- The result is in erased form since equality saturation may combine
+-- expressions of different types. Users can attempt to reconstruct
+-- typed expressions from the erased form if needed.
+--
+-- Example:
+--
+-- @
+-- let (classId, egraph) = addI (TConst 42) emptyEGraphI
+-- let best = extractBestI egraph depthCostI classId
+-- @
+extractBestI :: forall k a (l :: k -> Type -> Type) cost.
+                (LanguageI l, SOrd k, Ord cost)
+             => EGraphI a l
+             -> CostFunction (ErasedLang l) cost
+             -> ClassId
+             -> Fix (ErasedLang l)
+extractBestI (EGraphI eg) cost classId =
+    case erasedIsLanguage @k @l of
+        Dict -> extractBest eg cost classId
+{-# INLINE extractBestI #-}
+
+-- | Simple depth-based cost function for indexed languages.
+--
+-- The deeper the expression tree, the higher the cost.
+-- This is useful as a default cost function when you want
+-- simpler (shallower) expressions.
+depthCostI :: forall k (l :: k -> Type -> Type).
+              (LanguageI l, SOrd k)
+           => CostFunction (ErasedLang l) Int
+depthCostI = case erasedIsLanguage @k @l of
+    Dict -> depthCost
+{-# INLINE depthCostI #-}

--- a/src/Data/Equality/Graph/Indexed.hs
+++ b/src/Data/Equality/Graph/Indexed.hs
@@ -1,0 +1,151 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE IncoherentInstances #-}
+{-|
+Module      : Data.Equality.Graph.Indexed
+Description : Type-indexed e-graph wrapper
+Copyright   : (c) 2024
+License     : BSD-3-Clause
+
+This module provides a type-indexed wrapper around the standard e-graph that
+maintains type safety for type-indexed expression languages.
+
+The key insight is that while the underlying e-graph stores type-erased
+expressions via 'ErasedLang', the typed interface ensures that expressions
+are correctly typed when added and can be extracted with their types.
+
+Example usage:
+
+@
+-- Create empty indexed e-graph
+let eg = emptyEGraphI :: EGraphI () TExpr
+
+-- Add typed expressions
+let c1 = TConst 1 :: TExpr '[] 'TyInt ClassId
+    (id1, eg1) = addI c1 eg
+
+-- Merge and rebuild work as normal
+let (merged, eg2) = mergeI id1 id1 eg1
+    eg3 = rebuildI eg2
+@
+-}
+module Data.Equality.Graph.Indexed
+    ( -- * Indexed E-Graph type
+      EGraphI(..)
+      -- * Construction
+    , emptyEGraphI
+      -- * E-graph operations
+    , addI
+    , mergeI
+    , rebuildI
+      -- * Querying
+    , findI
+    , canonicalizeI
+    ) where
+
+import Data.Kind (Type)
+
+import Data.Equality.Graph (EGraph, ClassId, ENode(..))
+import qualified Data.Equality.Graph as EG
+import Data.Equality.Language.Indexed
+import Data.Equality.Analysis.Indexed
+import Data.Equality.Utils.Singleton
+import Data.Equality.Utils.Untyped
+
+-- | Type-indexed e-graph wrapper.
+--
+-- This newtype wraps an 'EGraph' over 'ErasedLang' to provide type-safe
+-- operations for type-indexed expression languages.
+--
+-- The type parameters are:
+--
+-- * @a@ - The analysis domain
+-- * @l@ - The type-indexed language functor with kind @k -> Type -> Type@
+newtype EGraphI a (l :: k -> Type -> Type) = EGraphI
+    { getEGraphI :: EGraph a (ErasedLang l)
+      -- ^ Access the underlying untyped e-graph
+    }
+
+-- | Create an empty indexed e-graph.
+emptyEGraphI :: forall k a (l :: k -> Type -> Type).
+                (LanguageI l, SOrd k)
+             => EGraphI a l
+emptyEGraphI = case erasedIsLanguage @k @l of
+    Dict -> EGraphI EG.emptyEGraph
+{-# INLINE emptyEGraphI #-}
+
+-- | Add a type-indexed e-node to the e-graph.
+--
+-- The e-node's children should be 'ClassId's referencing existing e-classes.
+-- Returns the class ID of the (possibly new) e-class containing the e-node.
+--
+-- If an equivalent e-node already exists, returns its existing class ID
+-- (hashcons behavior).
+addI :: forall k a (l :: k -> Type -> Type) dom.
+        (LanguageI l, SOrd k, AnalysisI a l, SingI dom)
+     => l dom ClassId
+     -> EGraphI a l
+     -> (ClassId, EGraphI a l)
+addI node (EGraphI eg) =
+    case erasedIsLanguage @k @l of
+        Dict ->
+            let erasedNode = Node (ErasedLang (Untyped node))
+                (cid, eg') = EG.add erasedNode eg
+            in (cid, EGraphI eg')
+{-# INLINE addI #-}
+
+-- | Merge two e-classes by their class IDs.
+--
+-- After merging, both class IDs will refer to the same equivalence class.
+-- E-graph invariants may be temporarily broken; call 'rebuildI' to restore them.
+mergeI :: forall k a (l :: k -> Type -> Type).
+          (LanguageI l, SOrd k, AnalysisI a l)
+       => ClassId
+       -> ClassId
+       -> EGraphI a l
+       -> (ClassId, EGraphI a l)
+mergeI c1 c2 (EGraphI eg) =
+    case erasedIsLanguage @k @l of
+        Dict ->
+            let (cid, eg') = EG.merge c1 c2 eg
+            in (cid, EGraphI eg')
+{-# INLINE mergeI #-}
+
+-- | Rebuild the e-graph to restore invariants.
+--
+-- After performing merges, the e-graph may have broken invariants (deduplication
+-- and congruence). This function restores them.
+rebuildI :: forall k a (l :: k -> Type -> Type).
+            (LanguageI l, SOrd k, AnalysisI a l)
+         => EGraphI a l
+         -> EGraphI a l
+rebuildI (EGraphI eg) =
+    case erasedIsLanguage @k @l of
+        Dict -> EGraphI (EG.rebuild eg)
+{-# INLINE rebuildI #-}
+
+-- | Find the canonical representative of an e-class.
+findI :: EGraphI a l -> ClassId -> ClassId
+findI (EGraphI eg) cid = EG.find cid eg
+{-# INLINE findI #-}
+
+-- | Canonicalize an indexed e-node.
+--
+-- Replaces all child class IDs with their canonical representatives.
+canonicalizeI :: forall k a (l :: k -> Type -> Type) dom.
+                 (Functor (l dom))
+              => EGraphI a l
+              -> l dom ClassId
+              -> l dom ClassId
+canonicalizeI (EGraphI eg) node = fmap (`EG.find` eg) node
+{-# INLINE canonicalizeI #-}

--- a/src/Data/Equality/Graph/Monad/Indexed.hs
+++ b/src/Data/Equality/Graph/Monad/Indexed.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-|
+Module      : Data.Equality.Graph.Monad.Indexed
+Description : Monadic interface for type-indexed e-graphs
+Copyright   : (c) 2024
+License     : BSD-3-Clause
+
+This module provides a monadic interface to type-indexed e-graph operations,
+similar to 'Data.Equality.Graph.Monad' but for type-indexed languages.
+
+Example usage:
+
+@
+result = egraphI $ do
+    id1 <- addIM (TConst 1)
+    id2 <- addIM (TConst 2)
+    id3 <- addIM (TAdd id1 id2)
+    mergeIM id1 id2
+    rebuildIM
+    return id3
+@
+-}
+module Data.Equality.Graph.Monad.Indexed
+    ( -- * E-graph stateful computation
+      EGraphIM
+    , egraphI
+    , runEGraphIM
+      -- * Operations
+    , addIM
+    , mergeIM
+    , rebuildIM
+    , findIM
+    , canonicalizeIM
+      -- * State operations
+    , getEGraphIM
+    , modifyEGraphIM
+      -- * Re-exports
+    , module Control.Monad.Trans.State.Strict
+    ) where
+
+import Control.Monad.Trans.State.Strict
+import Data.Kind (Type)
+
+import Data.Equality.Graph (ClassId)
+import Data.Equality.Graph.Indexed
+import Data.Equality.Language.Indexed
+import Data.Equality.Analysis.Indexed
+import Data.Equality.Utils.Singleton
+
+-- | Type-indexed e-graph stateful computation.
+type EGraphIM a l = State (EGraphI a l)
+
+-- | Run an indexed e-graph computation on an empty e-graph.
+--
+-- === Example
+-- @
+-- egraphI $ do
+--   id1 <- addIM (TConst 1)
+--   id2 <- addIM (TConst 2)
+--   mergeIM id1 id2
+-- @
+egraphI :: (LanguageI l, SOrd k)
+        => EGraphIM a (l :: k -> Type -> Type) r
+        -> (r, EGraphI a l)
+egraphI = runEGraphIM emptyEGraphI
+{-# INLINE egraphI #-}
+
+-- | Run an indexed e-graph computation on a given e-graph.
+runEGraphIM :: EGraphI a l -> EGraphIM a l r -> (r, EGraphI a l)
+runEGraphIM = flip runState
+{-# INLINE runEGraphIM #-}
+
+-- | Add a type-indexed e-node in the state monad.
+addIM :: forall k a (l :: k -> Type -> Type) dom.
+         (LanguageI l, SOrd k, AnalysisI a l, SingI dom)
+      => l dom ClassId
+      -> EGraphIM a l ClassId
+addIM node = state (addI node)
+{-# INLINE addIM #-}
+
+-- | Merge two e-classes in the state monad.
+mergeIM :: forall k a (l :: k -> Type -> Type).
+           (LanguageI l, SOrd k, AnalysisI a l)
+        => ClassId
+        -> ClassId
+        -> EGraphIM a l ClassId
+mergeIM c1 c2 = state (mergeI c1 c2)
+{-# INLINE mergeIM #-}
+
+-- | Rebuild the e-graph to restore invariants.
+rebuildIM :: forall k a (l :: k -> Type -> Type).
+             (LanguageI l, SOrd k, AnalysisI a l)
+          => EGraphIM a l ()
+rebuildIM = modify rebuildI
+{-# INLINE rebuildIM #-}
+
+-- | Find the canonical representative of an e-class.
+findIM :: ClassId -> EGraphIM a l ClassId
+findIM cid = gets (`findI` cid)
+{-# INLINE findIM #-}
+
+-- | Canonicalize an indexed e-node in the state monad.
+canonicalizeIM :: forall k a (l :: k -> Type -> Type) dom.
+                  (Functor (l dom))
+               => l dom ClassId
+               -> EGraphIM a l (l dom ClassId)
+canonicalizeIM node = gets (`canonicalizeI` node)
+{-# INLINE canonicalizeIM #-}
+
+-- | Get the current e-graph.
+getEGraphIM :: EGraphIM a l (EGraphI a l)
+getEGraphIM = get
+{-# INLINE getEGraphIM #-}
+
+-- | Modify the e-graph with a function.
+modifyEGraphIM :: (EGraphI a l -> EGraphI a l) -> EGraphIM a l ()
+modifyEGraphIM = modify
+{-# INLINE modifyEGraphIM #-}

--- a/src/Data/Equality/Language/Indexed.hs
+++ b/src/Data/Equality/Language/Indexed.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-|
+Module      : Data.Equality.Language.Indexed
+Description : Language constraint for type-indexed expressions
+Copyright   : (c) 2024
+License     : BSD-3-Clause
+
+This module provides the 'LanguageI' constraint for type-indexed expression
+languages, analogous to the 'Language' constraint but for languages with
+an additional type index parameter.
+
+A type-indexed language functor has the form @l :: k -> Type -> Type@
+where:
+
+* The first parameter @k@ is the domain type (result type)
+* The second parameter @Type@ is the recursive position type
+
+Example:
+
+@
+data TExpr (dom :: Ty) a where
+    TConst :: Int -> TExpr 'TyInt a
+    TAdd   :: a -> a -> TExpr 'TyInt a
+
+-- TExpr satisfies LanguageI when it has:
+-- - Functor (TExpr dom) for all dom
+-- - Foldable (TExpr dom) for all dom
+-- - Traversable (TExpr dom) for all dom
+-- - Ord (TExpr dom a) for all dom and Ord a
+@
+-}
+module Data.Equality.Language.Indexed
+    ( -- * Language constraint for indexed languages
+      LanguageI
+      -- * Constraint dictionary
+    , Dict(..)
+      -- * Proof of Language constraint for ErasedLang
+    , erasedIsLanguage
+    ) where
+
+import Data.Kind (Type, Constraint)
+
+import Data.Equality.Language
+import Data.Equality.Utils.Singleton
+import Data.Equality.Utils.Untyped
+
+-- | Constraint dictionary. Allows reifying a constraint into a value
+-- that can be passed around and pattern matched on to bring the
+-- constraint back into scope.
+data Dict (c :: Constraint) where
+    Dict :: c => Dict c
+
+-- | A 'LanguageI' is the required constraint on type-indexed expressions
+-- that are to be represented in an e-graph.
+--
+-- This mirrors the 'Language' constraint but for type-indexed languages
+-- with kind @k -> Type -> Type@.
+--
+-- For a type-indexed language to be usable with e-graphs:
+--
+-- 1. It must be 'Traversable' for all type index instantiations
+-- 2. It must have 'Ord' for all type index instantiations when the
+--    recursive position has 'Ord'
+--
+-- These constraints ensure that 'ErasedLang l' satisfies the regular
+-- 'Language' constraint.
+type LanguageI :: forall k. (k -> Type -> Type) -> Constraint
+class ( forall dom. Traversable (l dom)
+      , forall dom a. (SingI dom, Ord a) => Ord (l dom a)
+      ) => LanguageI l
+
+instance ( forall dom. Traversable (l dom)
+         , forall dom a. (SingI dom, Ord a) => Ord (l dom a)
+         ) => LanguageI l
+
+-- | Proof that 'ErasedLang l' satisfies the 'Language' constraint whenever
+-- @l@ satisfies 'LanguageI' and the kind @k@ has decidable equality and
+-- ordering.
+--
+-- This function returns a constraint dictionary that can be pattern matched
+-- on to bring the 'Language (ErasedLang l)' constraint into scope.
+--
+-- Example usage:
+--
+-- @
+-- case erasedIsLanguage @MyKind @MyLang of
+--     Dict -> -- Here, Language (ErasedLang MyLang) is in scope
+--         equalitySaturation (getEGraphI egraph) ...
+-- @
+erasedIsLanguage :: forall k (l :: k -> Type -> Type).
+                    (LanguageI l, SOrd k)
+                 => Dict (Language (ErasedLang l))
+erasedIsLanguage = Dict
+{-# INLINE erasedIsLanguage #-}

--- a/src/Data/Equality/Matching/Indexed.hs
+++ b/src/Data/Equality/Matching/Indexed.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-|
+Module      : Data.Equality.Matching.Indexed
+Description : Type-indexed e-matching
+Copyright   : (c) 2024
+License     : BSD-3-Clause
+
+This module provides type-indexed e-matching that works with type-indexed
+patterns and e-graphs while delegating to the standard e-matching infrastructure.
+
+The key insight is that we can erase type index for matching and then
+provide a typed interface over the results.
+
+Example:
+
+@
+-- Create a typed pattern
+pattern1 :: PatternI TExpr 'TyInt
+pattern1 = patI (TAdd \"x\" \"y\")
+
+-- Match against an indexed e-graph
+matches = ematchI egraphI pattern1
+@
+-}
+module Data.Equality.Matching.Indexed
+    ( -- * Type-indexed e-matching
+      ematchI
+      -- * Database conversion
+    , eGraphToDatabaseI
+      -- * Query compilation
+    , compileToQueryI
+      -- * Re-exports
+    , Match(..)
+    , Database
+    , Query
+    , VarsState(..)
+    , findVarName
+    ) where
+
+import Data.Kind (Type)
+
+import Data.Equality.Graph.Indexed
+import Data.Equality.Matching
+import Data.Equality.Matching.Database (Database, Query, Var)
+import Data.Equality.Matching.Pattern.Indexed
+import Data.Equality.Language.Indexed
+import Data.Equality.Utils.Singleton
+import Data.Equality.Utils.Untyped
+
+-- | Match a type-indexed pattern against an indexed e-graph.
+--
+-- This function erases the type index from the pattern and e-graph,
+-- performs standard e-matching, and returns the matches.
+--
+-- The returned 'Match' contains substitutions mapping pattern variable
+-- names to e-class IDs.
+--
+-- Example:
+--
+-- @
+-- let pat = patI (TAdd \"x\" \"y\") :: PatternI TExpr 'TyInt
+-- let matches = ematchI db pat
+-- -- Each match contains a substitution for \"x\" and \"y\"
+-- @
+ematchI :: forall k (l :: k -> Type -> Type) dom.
+           (LanguageI l, SOrd k, Functor (l dom))
+        => Database (ErasedLang l)
+        -> PatternI l dom
+        -> [Match]
+ematchI db patI' =
+    let erasedPat = erasePatternI patI'
+        (query, root) = fst $ compileToQuery erasedPat
+    in ematch db (query, root)
+{-# INLINE ematchI #-}
+
+-- | Convert an indexed e-graph to a database for e-matching.
+--
+-- The database can be reused across multiple pattern matches on the
+-- same e-graph state.
+--
+-- Example:
+--
+-- @
+-- let db = eGraphToDatabaseI egraph
+-- let matches1 = ematchI db pattern1
+-- let matches2 = ematchI db pattern2
+-- @
+eGraphToDatabaseI :: forall k a (l :: k -> Type -> Type).
+                     (LanguageI l, SOrd k)
+                  => EGraphI a l
+                  -> Database (ErasedLang l)
+eGraphToDatabaseI egi =
+    case erasedIsLanguage @k @l of
+        Dict -> eGraphToDatabase (getEGraphI egi)
+{-# INLINE eGraphToDatabaseI #-}
+
+-- | Compile a type-indexed pattern to a query.
+--
+-- Returns the query and root variable along with the variable state
+-- mapping pattern variable names to internal variables.
+--
+-- This is useful when you need access to the variable mappings for
+-- interpreting match results.
+compileToQueryI :: forall k (l :: k -> Type -> Type) dom.
+                   (LanguageI l, SOrd k, Functor (l dom))
+                => PatternI l dom
+                -> ((Query (ErasedLang l), Var), VarsState)
+compileToQueryI patI' = compileToQuery (erasePatternI patI')
+{-# INLINE compileToQueryI #-}

--- a/src/Data/Equality/Matching/Pattern/Indexed.hs
+++ b/src/Data/Equality/Matching/Pattern/Indexed.hs
@@ -1,0 +1,134 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-|
+Module      : Data.Equality.Matching.Pattern.Indexed
+Description : Type-indexed patterns for type-safe e-matching
+Copyright   : (c) 2024
+License     : BSD-3-Clause
+
+This module provides type-indexed patterns that preserve type information
+while supporting conversion to standard patterns for e-matching.
+
+A 'PatternI' carries type index that matches the corresponding indexed
+language, ensuring patterns are well-typed at compile time.
+
+Example:
+
+@
+-- A type-indexed pattern for TExpr
+pattern1 :: PatternI TExpr 'TyInt
+pattern1 = patI (TAdd \"x\" \"y\")
+
+-- Erase to use with standard e-matching
+erasedPat :: Pattern (ErasedLang TExpr)
+erasedPat = erasePatternI pattern1
+@
+-}
+module Data.Equality.Matching.Pattern.Indexed
+    ( -- * Type-indexed patterns
+      PatternI(..)
+      -- * Smart constructors
+    , patI
+      -- * Erasure
+    , erasePatternI
+    ) where
+
+import Data.Kind (Type)
+import Data.String (IsString(..))
+
+import Data.Equality.Matching.Pattern (Pattern(..))
+import Data.Equality.Utils.Singleton
+import Data.Equality.Utils.Untyped
+import Data.Equality.Language.Indexed
+
+-- | A type-indexed pattern that preserves type information.
+--
+-- @PatternI l dom@ is a pattern for expressions of type @l dom@,
+-- where @dom@ is the result type.
+--
+-- * 'NonVariablePatternI' matches a specific expression constructor
+-- * 'VariablePatternI' matches any expression (wildcard)
+data PatternI (l :: k -> Type -> Type) (dom :: k) where
+    -- | Pattern matching a specific constructor.
+    -- The children are patterns themselves.
+    NonVariablePatternI :: SingI dom
+                        => l dom (PatternI l dom')
+                        -> PatternI l dom
+    -- | Variable pattern (wildcard) that matches any expression.
+    -- Variables are identified by strings for named matching.
+    VariablePatternI :: SingI dom
+                     => String
+                     -> PatternI l dom
+
+-- | Smart constructor for 'NonVariablePatternI'.
+--
+-- Example:
+--
+-- @
+-- patI (TAdd \"x\" \"y\") :: PatternI TExpr 'TyInt
+-- @
+patI :: SingI dom
+     => l dom (PatternI l dom')
+     -> PatternI l dom
+patI = NonVariablePatternI
+{-# INLINE patI #-}
+
+-- | 'IsString' instance allows using string literals for variable patterns.
+--
+-- With @OverloadedStrings@, you can write:
+--
+-- @
+-- \"x\" :: PatternI l dom
+-- @
+instance SingI dom => IsString (PatternI l dom) where
+    fromString = VariablePatternI
+    {-# INLINE fromString #-}
+
+-- | Convert a type-indexed pattern to a standard pattern over 'ErasedLang'.
+--
+-- This allows type-indexed patterns to be used with the existing
+-- e-matching infrastructure.
+--
+-- The conversion wraps each pattern node in 'Untyped' and 'ErasedLang',
+-- preserving the structure while erasing type index.
+erasePatternI :: forall k (l :: k -> Type -> Type) dom.
+                 (Functor (l dom), LanguageI l, SOrd k)
+              => PatternI l dom
+              -> Pattern (ErasedLang l)
+erasePatternI (VariablePatternI s) = VariablePattern s
+erasePatternI (NonVariablePatternI node) =
+    NonVariablePattern (ErasedLang (Untyped (fmap erasePatternI' node)))
+  where
+    -- Helper for recursive erasure without requiring Functor constraint
+    erasePatternI' :: forall dom'. PatternI l dom' -> Pattern (ErasedLang l)
+    erasePatternI' (VariablePatternI s) = VariablePattern s
+    erasePatternI' (NonVariablePatternI n) =
+        NonVariablePattern (ErasedLang (Untyped (fmap erasePatternI' n)))
+{-# INLINE erasePatternI #-}
+
+-- | Eq instance compares via erasure.
+--
+-- Two patterns are equal if their erased forms are equal.
+instance (LanguageI l, SOrd k,
+          forall dom'. Functor (l dom'),
+          forall a. Eq a => Eq (ErasedLang l a))
+         => Eq (PatternI (l :: k -> Type -> Type) dom) where
+    p1 == p2 = erasePatternI p1 == erasePatternI p2
+    {-# INLINE (==) #-}
+
+-- | Show instance displays pattern structure.
+instance (forall dom' a. Show a => Show (l dom' a))
+         => Show (PatternI l dom) where
+    showsPrec _ (VariablePatternI s) = showString (show s)
+    showsPrec d (NonVariablePatternI x) = showsPrec d x

--- a/src/Data/Equality/Saturation/Indexed.hs
+++ b/src/Data/Equality/Saturation/Indexed.hs
@@ -1,0 +1,158 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-|
+Module      : Data.Equality.Saturation.Indexed
+Description : Type-indexed equality saturation
+Copyright   : (c) 2024
+License     : BSD-3-Clause
+
+This module provides type-indexed equality saturation that works with
+type-indexed rewrites while leveraging the standard equality saturation
+infrastructure via type erasure.
+
+The key insight is that equality saturation operates on the erased
+representation, and type-indexed rewrites are converted to standard
+rewrites via 'eraseSomeRewrite'.
+
+Example:
+
+@
+-- Define type-indexed rewrites
+commuteAdd :: SomeRewrite () TExpr
+commuteAdd = ruleI (patI (TAdd \"x\" \"y\")) (patI (TAdd \"y\" \"x\"))
+
+-- Run equality saturation on erased expression
+(result, finalGraph) = equalitySaturationI erasedExpr [commuteAdd] cost
+@
+-}
+module Data.Equality.Saturation.Indexed
+    ( -- * Type-indexed equality saturation
+      equalitySaturationI
+    , equalitySaturationI'
+    , runEqualitySaturationI
+      -- * Re-exports
+    , SomeRewrite(..)
+    , ruleI
+    , CostFunction
+    , Fix(..)
+    ) where
+
+import Data.Kind (Type)
+
+import Control.Monad.Trans.State.Strict (runState)
+
+import Data.Equality.Utils (Fix(..))
+import Data.Equality.Graph (EGraph)
+import Data.Equality.Graph.Indexed
+import Data.Equality.Extraction (CostFunction)
+import Data.Equality.Saturation (equalitySaturation', runEqualitySaturation)
+import Data.Equality.Saturation.Rewrites (Rewrite)
+import Data.Equality.Saturation.Rewrites.Indexed
+import Data.Equality.Saturation.Scheduler
+import Data.Equality.Language (Language)
+import Data.Equality.Language.Indexed
+import Data.Equality.Analysis (Analysis)
+import Data.Equality.Analysis.Indexed
+import Data.Equality.Utils.Singleton
+import Data.Equality.Utils.Untyped (ErasedLang)
+
+-- | Equality saturation with defaults for type-indexed rewrites.
+--
+-- Takes an erased expression, a list of type-indexed rewrites, and a cost
+-- function. Returns the best equivalent expression and the resulting e-graph
+-- wrapped in the indexed wrapper.
+--
+-- The expression is given in erased form ('Fix (ErasedLang l)') since
+-- equality saturation operates on the type-erased representation internally.
+--
+-- Example:
+--
+-- @
+-- let commute = ruleI (patI (TAdd \"x\" \"y\")) (patI (TAdd \"y\" \"x\"))
+-- let (best, egraph) = equalitySaturationI erasedExpr [commute] costFn
+-- @
+equalitySaturationI :: forall k a (l :: k -> Type -> Type) cost.
+                       ( LanguageI l
+                       , SOrd k
+                       , AnalysisI a l
+                       , Ord cost
+                       , forall dom. Functor (l dom)
+                       )
+                    => Fix (ErasedLang l)              -- ^ Expression to run equality saturation on
+                    -> [SomeRewrite a l]               -- ^ List of type-indexed rewrite rules
+                    -> CostFunction (ErasedLang l) cost -- ^ Cost function
+                    -> (Fix (ErasedLang l), EGraphI a l) -- ^ Best expression and resulting e-graph
+equalitySaturationI = equalitySaturationI' defaultBackoffScheduler
+{-# INLINE equalitySaturationI #-}
+
+-- | Equality saturation with custom scheduler for type-indexed rewrites.
+--
+-- This variant allows specifying a custom scheduler for controlling
+-- rewrite rule application.
+equalitySaturationI' :: forall k a (l :: k -> Type -> Type) schd cost.
+                        ( LanguageI l
+                        , SOrd k
+                        , AnalysisI a l
+                        , Scheduler (ErasedLang l) schd
+                        , Ord cost
+                        , forall dom. Functor (l dom)
+                        )
+                     => schd                             -- ^ Scheduler to use
+                     -> Fix (ErasedLang l)               -- ^ Expression to run equality saturation on
+                     -> [SomeRewrite a l]                -- ^ List of type-indexed rewrite rules
+                     -> CostFunction (ErasedLang l) cost -- ^ Cost function
+                     -> (Fix (ErasedLang l), EGraphI a l) -- ^ Best expression and resulting e-graph
+equalitySaturationI' schd expr rewrites cost =
+    case erasedIsLanguage @k @l of
+        Dict ->
+            let erasedRewrites = map eraseSomeRewrite rewrites
+                (bestExpr, eg) = equalitySaturation' schd expr erasedRewrites cost
+            in (bestExpr, EGraphI eg)
+{-# INLINE equalitySaturationI' #-}
+
+-- | Run equality saturation on an indexed e-graph.
+--
+-- This function applies rewrite rules to an indexed e-graph until
+-- saturation or the iteration limit is reached, returning the saturated
+-- e-graph.
+--
+-- Note: This runs saturation on the e-graph without extracting a result.
+-- For full equality saturation with extraction, use 'equalitySaturationI'.
+runEqualitySaturationI :: forall k a (l :: k -> Type -> Type) schd.
+                          ( LanguageI l
+                          , SOrd k
+                          , AnalysisI a l
+                          , Scheduler (ErasedLang l) schd
+                          , forall dom. Functor (l dom)
+                          )
+                       => schd              -- ^ Scheduler to use
+                       -> [SomeRewrite a l] -- ^ List of type-indexed rewrite rules
+                       -> EGraphI a l       -- ^ E-graph to saturate
+                       -> EGraphI a l       -- ^ Saturated e-graph
+runEqualitySaturationI schd rewrites (EGraphI eg) =
+    case erasedIsLanguage @k @l of
+        Dict ->
+            let erasedRewrites = map eraseSomeRewrite rewrites
+                ((), eg') = runEGraphMSat schd erasedRewrites eg
+            in EGraphI eg'
+  where
+    -- Helper to run saturation in e-graph monad
+    runEGraphMSat :: (Analysis a (ErasedLang l), Language (ErasedLang l), Scheduler (ErasedLang l) s)
+                  => s
+                  -> [Rewrite a (ErasedLang l)]
+                  -> EGraph a (ErasedLang l)
+                  -> ((), EGraph a (ErasedLang l))
+    runEGraphMSat s rws egraph =
+        runState (runEqualitySaturation s rws) egraph
+{-# INLINE runEqualitySaturationI #-}

--- a/src/Data/Equality/Saturation/Rewrites/Indexed.hs
+++ b/src/Data/Equality/Saturation/Rewrites/Indexed.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-|
+Module      : Data.Equality.Saturation.Rewrites.Indexed
+Description : Type-preserving rewrites for type-indexed expressions
+Copyright   : (c) 2024
+License     : BSD-3-Clause
+
+This module provides type-indexed rewrites that enforce type preservation
+at compile time. The left-hand side and right-hand side of a rewrite must
+have matching type index, ensuring type-safe transformations.
+
+A key property is that attempting to create a rewrite between expressions
+of different types will result in a compile-time type error.
+
+Example:
+
+@
+-- Type-preserving commutativity rule (compiles)
+commute :: RewriteI () TExpr 'TyInt
+commute = patI (TAdd \"x\" \"y\") :=: patI (TAdd \"y\" \"x\")
+
+-- Ill-typed rule (does NOT compile - type mismatch!)
+-- badRule = patI (TConst 1) :=: patI (TBool True)
+@
+-}
+module Data.Equality.Saturation.Rewrites.Indexed
+    ( -- * Type-indexed rewrites
+      RewriteI(..)
+      -- * Existential wrapper
+    , SomeRewrite(..)
+      -- * Smart constructors
+    , ruleI
+      -- * Rewrite conditions
+    , RewriteConditionI
+      -- * Erasure
+    , eraseRewriteI
+    , eraseSomeRewrite
+    ) where
+
+import Data.Kind (Type)
+
+import Data.Equality.Graph (EGraph)
+import Data.Equality.Matching (VarsState)
+import Data.Equality.Matching.Database (Subst)
+import Data.Equality.Matching.Pattern.Indexed
+import Data.Equality.Saturation.Rewrites (Rewrite(..))
+import Data.Equality.Utils.Singleton
+import Data.Equality.Utils.Untyped
+import Data.Equality.Language.Indexed
+
+-- | A type-indexed rewrite rule that enforces type preservation.
+--
+-- Both the left-hand side and right-hand side patterns must have the same
+-- type index @dom@, ensuring the rewrite preserves types.
+--
+-- * @:=:@ creates a simple rewrite rule
+-- * @:|:@ adds a condition to a rewrite rule
+data RewriteI anl (l :: k -> Type -> Type) (dom :: k) where
+    -- | A simple rewrite from LHS pattern to RHS pattern.
+    -- Type index must match, enforcing type preservation.
+    (:=:) :: SingI dom
+          => !(PatternI l dom)
+          -> !(PatternI l dom)
+          -> RewriteI anl l dom
+
+    -- | A conditional rewrite that only applies when the condition is met.
+    (:|:) :: !(RewriteI anl l dom)
+          -> !(RewriteConditionI anl l)
+          -> RewriteI anl l dom
+
+infix 3 :=:
+infixl 2 :|:
+
+-- | A condition for applying a rewrite rule.
+--
+-- Takes the variable state, substitution, and e-graph, returning whether
+-- the condition is satisfied.
+type RewriteConditionI anl l = VarsState -> Subst -> EGraph anl (ErasedLang l) -> Bool
+
+-- | Existential wrapper for type-indexed rewrites.
+--
+-- This allows collecting rewrites with different type indices into
+-- a heterogeneous collection (e.g., a list).
+--
+-- The singleton witness @SingI@ is preserved,
+-- allowing type recovery when needed.
+data SomeRewrite anl (l :: k -> Type -> Type) where
+    SomeRewrite :: SingI dom
+                => RewriteI anl l dom
+                -> SomeRewrite anl l
+
+-- | Smart constructor for creating a 'SomeRewrite' from two patterns.
+--
+-- Example:
+--
+-- @
+-- commuteRule :: SomeRewrite () TExpr
+-- commuteRule = ruleI (patI (TAdd \"x\" \"y\")) (patI (TAdd \"y\" \"x\"))
+-- @
+ruleI :: SingI dom
+      => PatternI l dom
+      -> PatternI l dom
+      -> SomeRewrite anl l
+ruleI lhs rhs = SomeRewrite (lhs :=: rhs)
+{-# INLINE ruleI #-}
+
+-- | Erase a type-indexed rewrite to a standard rewrite over 'ErasedLang'.
+--
+-- This allows type-indexed rewrites to be used with the existing
+-- equality saturation infrastructure.
+eraseRewriteI :: forall k anl (l :: k -> Type -> Type) dom.
+                 (LanguageI l, SOrd k, forall dom'. Functor (l dom'))
+              => RewriteI anl l dom
+              -> Rewrite anl (ErasedLang l)
+eraseRewriteI (lhs :=: rhs) = erasePatternI lhs := erasePatternI rhs
+eraseRewriteI (rw :|: cond) = eraseRewriteI rw :| cond
+{-# INLINE eraseRewriteI #-}
+
+-- | Erase a 'SomeRewrite' to a standard rewrite.
+eraseSomeRewrite :: forall k anl (l :: k -> Type -> Type).
+                    (LanguageI l, SOrd k, forall dom. Functor (l dom))
+                 => SomeRewrite anl l
+                 -> Rewrite anl (ErasedLang l)
+eraseSomeRewrite (SomeRewrite rw) = eraseRewriteI rw
+{-# INLINE eraseSomeRewrite #-}
+
+-- | Show instance for debugging.
+instance (forall dom' a. Show a => Show (l dom' a))
+         => Show (RewriteI anl l dom) where
+    show (lhs :=: rhs) = show lhs ++ " :=: " ++ show rhs
+    show (rw :|: _) = show rw ++ " :|: <cond>"
+
+-- | Show instance for SomeRewrite.
+instance (forall dom a. Show a => Show (l dom a))
+         => Show (SomeRewrite anl l) where
+    show (SomeRewrite rw) = show rw

--- a/src/Data/Equality/Utils/HList.hs
+++ b/src/Data/Equality/Utils/HList.hs
@@ -1,0 +1,147 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-|
+Module      : Data.Equality.Utils.HList
+Description : Heterogeneous list infrastructure
+Copyright   : (c) 2024
+License     : BSD-3-Clause
+
+This module provides heterogeneous list infrastructure for representing lists
+of typed values, needed for function argument lists in type-indexed expressions.
+
+Example usage:
+
+@
+-- A list of terms with different types
+type Args = HList (Term env) '[TyInt, TyBool, TyString]
+
+-- Constructing an HList
+args :: Args
+args = intTerm `HCons` boolTerm `HCons` stringTerm `HCons` HNil
+@
+-}
+module Data.Equality.Utils.HList
+    ( -- * Heterogeneous lists
+      HList(..)
+      -- * Membership proofs
+    , In(..)
+      -- * Operations
+    , hLookup
+    , hMap
+    , hFoldr
+    , hLength
+      -- * Type-level length
+    , Length
+    ) where
+
+import Data.Kind (Type)
+import GHC.TypeLits (Nat, type (+))
+
+-- | Heterogeneous list indexed by a type-level list.
+--
+-- The @f@ parameter is a type constructor that wraps each element type,
+-- and @ts@ is the type-level list of element types.
+--
+-- For example, @HList Identity '[Int, Bool, String]@ contains an 'Int',
+-- a 'Bool', and a 'String'.
+data HList (f :: k -> Type) (ts :: [k]) where
+    HNil  :: HList f '[]
+    HCons :: f t -> HList f ts -> HList f (t ': ts)
+
+infixr 5 `HCons`
+
+-- | Type-safe proof that a type @t@ is a member of the type-level list @ts@.
+--
+-- This GADT acts as a type-safe index into an HList. 'Here' indicates the
+-- element is at the head, while 'There' indicates it's further in the list.
+data In (t :: k) (ts :: [k]) where
+    Here  :: In t (t ': ts)
+    There :: In t ts -> In t (t' ': ts)
+
+-- | Lookup an element in an HList by its membership proof.
+--
+-- This is guaranteed to succeed because the 'In' proof ensures the
+-- element exists at the correct position.
+hLookup :: In t ts -> HList f ts -> f t
+hLookup Here      (HCons x _)  = x
+hLookup (There i) (HCons _ xs) = hLookup i xs
+{-# INLINE hLookup #-}
+
+-- | Map a natural transformation over all elements of an HList.
+--
+-- This preserves the type-level list structure while transforming
+-- each element from @f t@ to @g t@.
+hMap :: (forall t. f t -> g t) -> HList f ts -> HList g ts
+hMap _ HNil = HNil
+hMap f (HCons x xs) = HCons (f x) (hMap f xs)
+{-# INLINE hMap #-}
+
+-- | Right fold over an HList.
+--
+-- This allows uniform processing of all elements, discarding the
+-- type information at the result.
+hFoldr :: (forall t. f t -> b -> b) -> b -> HList f ts -> b
+hFoldr _ z HNil = z
+hFoldr f z (HCons x xs) = f x (hFoldr f z xs)
+{-# INLINE hFoldr #-}
+
+-- | Get the length of an HList at the term level.
+hLength :: HList f ts -> Int
+hLength = hFoldr (\_ acc -> acc + 1) 0
+{-# INLINE hLength #-}
+
+-- | Compute the length of a type-level list.
+type family Length (ts :: [k]) :: Nat where
+    Length '[] = 0
+    Length (_ ': ts) = 1 + Length ts
+
+-- | Show instance for empty HList.
+instance Show (HList f '[]) where
+    show HNil = "HNil"
+
+-- | Show instance for non-empty HList.
+instance (Show (f t), Show (HList f ts)) => Show (HList f (t ': ts)) where
+    showsPrec d (HCons x xs) = showParen (d > 5) $
+        showsPrec 6 x . showString " `HCons` " . showsPrec 5 xs
+
+-- | Eq instance for empty HList.
+instance Eq (HList f '[]) where
+    HNil == HNil = True
+    {-# INLINE (==) #-}
+
+-- | Eq instance for non-empty HList.
+instance (Eq (f t), Eq (HList f ts)) => Eq (HList f (t ': ts)) where
+    HCons x xs == HCons y ys = x == y && xs == ys
+    {-# INLINE (==) #-}
+
+-- | Ord instance for empty HList.
+instance Ord (HList f '[]) where
+    compare HNil HNil = EQ
+    {-# INLINE compare #-}
+
+-- | Ord instance for non-empty HList.
+instance (Ord (f t), Ord (HList f ts)) => Ord (HList f (t ': ts)) where
+    compare (HCons x xs) (HCons y ys) = case compare x y of
+        EQ -> compare xs ys
+        r  -> r
+    {-# INLINE compare #-}
+
+-- | Functor-like mapping when the HList parameter is a functor.
+-- Note: HList itself is not a Functor because it doesn't have kind Type -> Type.
+
+-- | Foldable-like operations.
+-- Note: HList itself is not Foldable for the same reason.
+
+-- | Traversable-like operations.
+-- Note: HList itself is not Traversable for the same reason.

--- a/src/Data/Equality/Utils/Singleton.hs
+++ b/src/Data/Equality/Utils/Singleton.hs
@@ -1,0 +1,203 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-|
+Module      : Data.Equality.Utils.Singleton
+Description : Singleton infrastructure for runtime type information
+Copyright   : (c) 2024
+License     : BSD-3-Clause
+
+This module provides foundational singleton infrastructure for runtime type
+information, enabling type-safe erasure and recovery of type indices.
+
+Users can provide their own 'Sing' instances (via Template Haskell with
+singletons-th, or manually) to use type-indexed expressions with hegg.
+
+Example:
+
+@
+data Ty = TyInt | TyBool | TyFunc Ty Ty
+
+data instance Sing (t :: Ty) where
+    STyInt  :: Sing 'TyInt
+    STyBool :: Sing 'TyBool
+    STyFunc :: Sing a -> Sing b -> Sing ('TyFunc a b)
+
+instance SingI 'TyInt where sing = STyInt
+instance SingI 'TyBool where sing = STyBool
+instance (SingI a, SingI b) => SingI ('TyFunc a b) where
+    sing = STyFunc sing sing
+@
+-}
+module Data.Equality.Utils.Singleton
+    ( -- * Core singleton types
+      Sing
+    , SingI(..)
+      -- * Type equality decisions
+    , SDecide(..)
+      -- * Ordering on singletons
+    , SOrd(..)
+    , SOrdering(..)
+      -- * Existential wrappers
+    , SomeType(..)
+    , withSomeType
+    , fromSomeType
+      -- * List-kinded singletons
+    , SingList(..)
+    , SingListI(..)
+    , sListLength
+      -- * List-level equality and ordering
+    , decEqList
+    , sCompareList
+      -- * Type equality
+    , (:~:)(..)
+    ) where
+
+import Data.Kind (Type, Constraint)
+import Data.Type.Equality ((:~:)(..))
+
+-- | Data family for singletons. Users provide instances for their own kinds.
+--
+-- A singleton is a type with exactly one inhabitant for each value of the
+-- indexed type. This allows runtime access to type-level information.
+type Sing :: k -> Type
+data family Sing (t :: k)
+
+-- | Typeclass for implicit singleton access.
+--
+-- Provides a way to obtain a singleton value when the type is known.
+type SingI :: forall k. k -> Constraint
+class SingI (t :: k) where
+    sing :: Sing t
+
+-- | Decision procedure for type equality.
+--
+-- Given two singleton values, decide whether the underlying types are equal.
+-- Returns 'Just Refl' if equal, 'Nothing' otherwise.
+--
+-- Users must implement this class for their custom kinds.
+class SDecide k where
+    decEq :: forall (a :: k) (b :: k). Sing a -> Sing b -> Maybe (a :~: b)
+
+-- | Ordering result at the type level.
+data SOrdering = SLT | SEQ | SGT
+    deriving (Eq, Ord, Show)
+
+-- | Ordering on singleton values.
+--
+-- Provides a total ordering on types of a given kind via their singletons.
+-- This is needed for storing type-erased values in ordered containers.
+class SDecide k => SOrd k where
+    sCompare :: forall (a :: k) (b :: k). Sing a -> Sing b -> SOrdering
+
+-- | Existential wrapper for types with singletons.
+--
+-- Hides the type index while preserving the ability to recover it at runtime.
+data SomeType k where
+    SomeType :: SingI t => Sing (t :: k) -> SomeType k
+
+-- | Eliminate a 'SomeType' by providing a continuation.
+withSomeType :: SomeType k -> (forall (t :: k). SingI t => Sing t -> r) -> r
+withSomeType (SomeType s) f = f s
+{-# INLINE withSomeType #-}
+
+-- | Attempt to recover a specific type from a 'SomeType'.
+--
+-- Returns 'Just' if the hidden type matches the expected type,
+-- 'Nothing' otherwise.
+fromSomeType :: forall k (t :: k). (SingI t, SDecide k)
+             => Sing t -> SomeType k -> Maybe (Sing t)
+fromSomeType expected (SomeType actual) = case decEq actual expected of
+    Just Refl -> Just actual
+    Nothing   -> Nothing
+{-# INLINE fromSomeType #-}
+
+-- | Eq instance for SomeType using SDecide.
+instance SDecide k => Eq (SomeType k) where
+    SomeType a == SomeType b = case decEq a b of
+        Just Refl -> True
+        Nothing   -> False
+    {-# INLINE (==) #-}
+
+-- | Ord instance for SomeType using SOrd.
+instance SOrd k => Ord (SomeType k) where
+    compare (SomeType a) (SomeType b) = case sCompare a b of
+        SLT -> LT
+        SEQ -> EQ
+        SGT -> GT
+    {-# INLINE compare #-}
+
+-- | Singleton for type-level lists.
+--
+-- This is a GADT that mirrors the structure of type-level lists at the term level.
+data SingList (ts :: [k]) where
+    SNil  :: SingList '[]
+    SCons :: Sing t -> SingList ts -> SingList (t ': ts)
+
+infixr 5 `SCons`
+
+-- | Typeclass for implicit list singleton access.
+type SingListI :: forall k. [k] -> Constraint
+class SingListI (ts :: [k]) where
+    singList :: SingList ts
+
+instance SingListI '[] where
+    singList = SNil
+    {-# INLINE singList #-}
+
+instance (SingI t, SingListI ts) => SingListI (t ': ts) where
+    singList = SCons sing singList
+    {-# INLINE singList #-}
+
+-- | Get the length of a singleton list.
+sListLength :: SingList ts -> Int
+sListLength sl = go sl
+  where
+    go :: SingList xs -> Int
+    go SNil = 0
+    go (SCons _ rest) = 1 + go rest
+{-# INLINE sListLength #-}
+
+-- | Show instance for SingList.
+instance Show (SingList '[]) where
+    show SNil = "SNil"
+
+instance (Show (Sing t), Show (SingList ts)) => Show (SingList (t ': ts)) where
+    showsPrec d (SCons x xs) = showParen (d > 5) $
+        showsPrec 6 x . showString " `SCons` " . showsPrec 5 xs
+
+-- | Decision procedure for type-level list equality.
+decEqList :: forall k (as :: [k]) (bs :: [k]). SDecide k
+          => SingList as -> SingList bs -> Maybe (as :~: bs)
+decEqList SNil SNil = Just Refl
+decEqList (SCons a as) (SCons b bs) = do
+    Refl <- decEq a b
+    Refl <- decEqList as bs
+    Just Refl
+decEqList _ _ = Nothing
+{-# INLINE decEqList #-}
+
+-- | Ordering for type-level lists.
+sCompareList :: forall k (as :: [k]) (bs :: [k]). SOrd k
+             => SingList as -> SingList bs -> SOrdering
+sCompareList SNil SNil = SEQ
+sCompareList SNil (SCons _ _) = SLT
+sCompareList (SCons _ _) SNil = SGT
+sCompareList (SCons a as) (SCons b bs) = case sCompare a b of
+    SLT -> SLT
+    SGT -> SGT
+    SEQ -> sCompareList as bs
+{-# INLINE sCompareList #-}

--- a/src/Data/Equality/Utils/Untyped.hs
+++ b/src/Data/Equality/Utils/Untyped.hs
@@ -1,0 +1,186 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeApplications #-}
+{-|
+Module      : Data.Equality.Utils.Untyped
+Description : Type erasure layer for indexed expressions
+Copyright   : (c) 2024
+License     : BSD-3-Clause
+
+This module provides the type-erasing wrapper infrastructure that allows
+type-indexed expressions to be stored in the untyped e-graph while
+preserving type information for reconstruction.
+
+The key insight is that 'ErasedLang l' satisfies the 'Language' constraint
+when 'l' is a proper type-indexed functor, allowing reuse of the entire
+existing e-graph infrastructure.
+
+Example:
+
+@
+-- A type-indexed expression language
+data TExpr (dom :: Ty) a where
+    TConst :: Int -> TExpr 'TyInt a
+    TAdd   :: a -> a -> TExpr 'TyInt a
+
+-- Wrap in Untyped to hide type indices
+wrapped :: Untyped TExpr ClassId
+wrapped = Untyped (TAdd someClassId otherClassId)
+
+-- ErasedLang provides Language instance for e-graph storage
+erased :: ErasedLang TExpr ClassId
+erased = ErasedLang wrapped
+@
+-}
+module Data.Equality.Utils.Untyped
+    ( -- * Type erasure
+      Untyped(..)
+    , UntypedWith(..)
+    , ErasedLang(..)
+      -- * Type recovery
+    , withUntyped
+    , matchType
+    ) where
+
+import Data.Kind (Type)
+import Data.Type.Equality ()
+
+import Data.Equality.Utils.Singleton
+
+-- | Kind alias for type-indexed language functors.
+--
+-- A type-indexed language functor has the form @l :: k -> Type -> Type@
+-- where:
+--
+-- * The first parameter @k@ is the domain type (result type)
+-- * The second parameter @Type@ is the recursive position type
+--
+-- Note: We don't use a type synonym because GHC doesn't support poly-kinded
+-- type synonyms well. Instead, we document the expected kind inline.
+
+-- | Type-erasing wrapper that preserves singleton witnesses.
+--
+-- This GADT existentially hides the type index @dom@ while
+-- keeping 'SingI' constraint that allows recovery of the
+-- type information at runtime.
+--
+-- The parameter @l@ has kind @k -> Type -> Type@.
+data Untyped l a where
+    Untyped :: SingI dom
+            => l dom a
+            -> Untyped l a
+
+-- | Type-erasing wrapper that also stores the singleton witness explicitly.
+--
+-- This variant preserves both explicit singleton value and implicit constraint,
+-- useful when you need to compare or order Untyped values.
+data UntypedWith l a where
+    UntypedWith :: SingI dom
+                => Sing dom -> l dom a -> UntypedWith l a
+
+-- | Convert to the explicit form for comparison.
+toUntypedWith :: Untyped l a -> UntypedWith l a
+toUntypedWith (Untyped x) = UntypedWith sing x
+{-# INLINE toUntypedWith #-}
+
+-- | Eliminate an 'Untyped' value by providing a continuation.
+withUntyped :: Untyped l a
+            -> (forall dom. SingI dom => l dom a -> r)
+            -> r
+withUntyped (Untyped x) f = f x
+{-# INLINE withUntyped #-}
+
+-- | Attempt to recover a specific type from an 'Untyped' value.
+--
+-- Returns 'Just' the underlying expression if the type index matches,
+-- 'Nothing' otherwise.
+matchType :: forall k (dom :: k) l a.
+             (SingI dom, SDecide k)
+          => Sing dom -> Untyped l a -> Maybe (l dom a)
+matchType expectedDom u =
+    case toUntypedWith u of
+        UntypedWith actualDom x ->
+            case decEq expectedDom actualDom of
+                Just Refl -> Just x
+                _ -> Nothing
+{-# INLINE matchType #-}
+
+-- | Newtype wrapper for Language instance derivation.
+--
+-- 'ErasedLang l' satisfies the 'Language' constraint when @l@ has appropriate
+-- instances, allowing type-indexed expressions to be used with the existing
+-- e-graph infrastructure.
+--
+-- The parameter @l@ has kind @k -> Type -> Type@.
+newtype ErasedLang l a =
+    ErasedLang { getErased :: Untyped l a }
+
+-- | Functor instance for ErasedLang using QuantifiedConstraints.
+instance (forall dom. Functor (l dom)) => Functor (ErasedLang l) where
+    fmap f (ErasedLang (Untyped x)) = ErasedLang (Untyped (fmap f x))
+    {-# INLINE fmap #-}
+
+-- | Foldable instance for ErasedLang.
+instance (forall dom. Foldable (l dom)) => Foldable (ErasedLang l) where
+    foldMap f (ErasedLang (Untyped x)) = foldMap f x
+    {-# INLINE foldMap #-}
+
+-- | Traversable instance for ErasedLang.
+instance (forall dom. Traversable (l dom)) => Traversable (ErasedLang l) where
+    traverse f (ErasedLang (Untyped x)) = ErasedLang . Untyped <$> traverse f x
+    {-# INLINE traverse #-}
+
+-- | Eq instance comparing type index first, then structure.
+--
+-- Two erased expressions are equal iff they have the same type index
+-- AND the same structure.
+--
+-- Note: The type parameter @l@ has kind @k -> Type -> Type@.
+instance (forall dom. SingI dom => Eq (l dom a), SDecide k)
+         => Eq (ErasedLang (l :: k -> Type -> Type) a) where
+    ErasedLang u1 == ErasedLang u2 =
+        case (toUntypedWith u1, toUntypedWith u2) of
+            (UntypedWith dom1 x, UntypedWith dom2 y) ->
+                case decEq dom1 dom2 of
+                    Just Refl -> x == y
+                    _ -> False
+    {-# INLINE (==) #-}
+
+-- | Ord instance providing consistent total ordering.
+--
+-- Orders by type index first (using SOrd), then by structure.
+-- This is needed for e-graph memo table storage.
+--
+-- Note: The type parameter @l@ has kind @k -> Type -> Type@.
+instance ( forall dom. SingI dom => Eq (l dom a)
+         , forall dom. SingI dom => Ord (l dom a)
+         , SOrd k
+         )
+         => Ord (ErasedLang (l :: k -> Type -> Type) a) where
+    compare (ErasedLang u1) (ErasedLang u2) =
+        case (toUntypedWith u1, toUntypedWith u2) of
+            (UntypedWith dom1 x, UntypedWith dom2 y) ->
+                case sCompare dom1 dom2 of
+                    SLT -> LT
+                    SGT -> GT
+                    SEQ -> case decEq dom1 dom2 of
+                        Just Refl -> compare x y
+                        -- This case is impossible since sCompare returned SEQ
+                        _ -> EQ
+    {-# INLINE compare #-}
+
+-- | Show instance for debugging.
+instance (forall dom. SingI dom => Show (l dom a))
+         => Show (ErasedLang l a) where
+    showsPrec d (ErasedLang (Untyped x)) = showParen (d > 10) $
+        showString "ErasedLang " . showsPrec 11 x

--- a/test/Indexed.hs
+++ b/test/Indexed.hs
@@ -1,0 +1,284 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-|
+Test module for type-indexed expression support.
+
+This module tests the full type-indexed infrastructure including:
+- Type erasure via ErasedLang
+- Indexed e-graph operations
+- Type-indexed patterns
+- Type-preserving rewrites
+- Indexed e-matching
+- Indexed equality saturation
+-}
+module Indexed where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Data.Kind (Type)
+
+import Data.Equality.Utils.Singleton ()
+import Data.Equality.Utils.Untyped ()
+import Data.Equality.Graph ()
+import Data.Equality.Graph.Indexed
+import Data.Equality.Graph.Monad.Indexed
+import Data.Equality.Matching.Indexed
+import Data.Equality.Matching.Pattern.Indexed
+import Data.Equality.Saturation.Rewrites.Indexed
+import Data.Equality.Saturation.Indexed
+import Data.Equality.Extraction.Indexed ()
+import Data.Equality.Language.Indexed ()
+import Data.Equality.Analysis.Indexed ()
+import Data.Equality.Saturation.Scheduler (defaultBackoffScheduler)
+import Data.Equality.Saturation.Rewrites (Rewrite(..))
+import Data.Equality.Matching.Pattern (Pattern(..))
+
+-- Import the Ty type and instances from Singleton test module
+import Singleton (Ty(..))
+
+--------------------------------------------------------------------------------
+-- Test Type-Indexed Language
+--------------------------------------------------------------------------------
+
+-- | A simple type-indexed expression language
+--
+-- The type parameters are:
+-- - @dom@: result type index
+-- - @a@: recursion parameter
+type TExpr :: Ty -> Type -> Type
+data TExpr dom a where
+    -- Constants
+    TInt  :: Int  -> TExpr 'TyInt a
+    TBool :: Bool -> TExpr 'TyBool a
+
+    -- Arithmetic
+    TAdd :: a -> a -> TExpr 'TyInt a
+    TMul :: a -> a -> TExpr 'TyInt a
+
+    -- Comparison
+    TEq  :: a -> a -> TExpr 'TyBool a
+
+    -- Conditional
+    TIf  :: a -> a -> a -> TExpr 'TyInt a
+
+deriving instance Show a => Show (TExpr dom a)
+deriving instance Eq a => Eq (TExpr dom a)
+deriving instance Functor (TExpr dom)
+deriving instance Foldable (TExpr dom)
+deriving instance Traversable (TExpr dom)
+
+-- | Ord instance required for Language
+--
+-- Note: Since TExpr is a GADT with type indices, we need a total ordering
+-- that works across all constructors. We assign each constructor a tag
+-- for cross-constructor comparison, and compare by content within the
+-- same constructor.
+instance Ord a => Ord (TExpr dom a) where
+    compare (TInt n1) (TInt n2) = compare n1 n2
+    compare (TBool b1) (TBool b2) = compare b1 b2
+    compare (TAdd l1 r1) (TAdd l2 r2) = compare (l1, r1) (l2, r2)
+    compare (TMul l1 r1) (TMul l2 r2) = compare (l1, r1) (l2, r2)
+    compare (TEq l1 r1) (TEq l2 r2) = compare (l1, r1) (l2, r2)
+    compare (TIf c1 t1 e1) (TIf c2 t2 e2) = compare (c1, t1, e1) (c2, t2, e2)
+    -- Cross-constructor comparisons: order by constructor tag
+    compare x y = compare (tag x) (tag y)
+      where
+        tag :: TExpr d b -> Int
+        tag TInt{}  = 0
+        tag TBool{} = 1
+        tag TAdd{}  = 2
+        tag TMul{}  = 3
+        tag TEq{}   = 4
+        tag TIf{}   = 5
+
+-- No need for explicit AnalysisI instance - generic () instance is used
+
+--------------------------------------------------------------------------------
+-- Test Suite
+--------------------------------------------------------------------------------
+
+-- Helper type alias for readability
+type TExprGraph = EGraphI () TExpr
+
+-- Helper to run TExpr computation
+runTExpr :: EGraphIM () TExpr a -> (a, TExprGraph)
+runTExpr = egraphI
+
+indexedTests :: TestTree
+indexedTests = testGroup "Type-Indexed Expressions"
+    [ testGroup "EGraphI Operations"
+        [ testCase "emptyEGraphI creates empty graph" $ do
+            let _eg = emptyEGraphI :: TExprGraph
+            -- Just verify it doesn't crash
+            return ()
+
+        , testCase "addI adds nodes and returns class IDs" $ do
+            let (cid, _) = runTExpr $ addIM (TInt 42)
+            cid @?= 1  -- First class should be 1
+
+        , testCase "addI with same node returns same class" $ do
+            let (result, _) = runTExpr $ do
+                    cid1 <- addIM (TInt 42)
+                    cid2 <- addIM (TInt 42)
+                    return (cid1, cid2)
+            fst result @?= snd result
+
+        , testCase "addI with different nodes returns different classes" $ do
+            let (result, _) = runTExpr $ do
+                    cid1 <- addIM (TInt 1)
+                    cid2 <- addIM (TInt 2)
+                    return (cid1, cid2)
+            fst result /= snd result @?= True
+
+        , testCase "compound expressions can be built" $ do
+            let (cid, _) = runTExpr $ do
+                    c1 <- addIM (TInt 1)
+                    c2 <- addIM (TInt 2)
+                    addIM (TAdd c1 c2)
+            cid @?= 3  -- Third class (after TInt 1 and TInt 2)
+        ]
+
+    , testGroup "PatternI"
+        [ testCase "patI creates non-variable patterns" $ do
+            let p :: PatternI TExpr 'TyInt
+                p = patI (TInt 42)
+            -- Just verify construction succeeds
+            case p of
+                NonVariablePatternI _ -> return ()
+                _ -> assertFailure "Expected NonVariablePatternI"
+
+        , testCase "string literal creates variable patterns" $ do
+            let p :: PatternI TExpr 'TyInt
+                p = "x"
+            case p of
+                VariablePatternI "x" -> return ()
+                _ -> assertFailure "Expected VariablePatternI"
+
+        , testCase "erasePatternI converts to standard pattern" $ do
+            let p :: PatternI TExpr 'TyInt
+                p = patI (TInt 42)
+                erased = erasePatternI p
+            -- Just verify erasure succeeds
+            case erased of
+                NonVariablePattern _ -> return ()
+                _ -> assertFailure "Expected NonVariablePattern"
+        ]
+
+    , testGroup "RewriteI"
+        [ testCase "(:=:) creates type-preserving rewrites" $ do
+            -- Commutativity: x + y = y + x
+            let x :: PatternI TExpr 'TyInt
+                x = "x"
+                y :: PatternI TExpr 'TyInt
+                y = "y"
+                rw :: RewriteI () TExpr 'TyInt
+                rw = patI (TAdd x y) :=: patI (TAdd y x)
+            -- Just verify construction succeeds
+            case rw of
+                _ :=: _ -> return ()
+                _ :|: _ -> assertFailure "Expected simple rewrite, not conditional"
+
+        , testCase "SomeRewrite wraps rewrites" $ do
+            let x :: PatternI TExpr 'TyInt
+                x = "x"
+                y :: PatternI TExpr 'TyInt
+                y = "y"
+                rw :: SomeRewrite () TExpr
+                rw = ruleI (patI (TAdd x y)) (patI (TAdd y x))
+            case rw of
+                SomeRewrite _ -> return ()
+
+        , testCase "eraseSomeRewrite converts to standard rewrite" $ do
+            let x :: PatternI TExpr 'TyInt
+                x = "x"
+                y :: PatternI TExpr 'TyInt
+                y = "y"
+                rw :: SomeRewrite () TExpr
+                rw = ruleI (patI (TAdd x y)) (patI (TAdd y x))
+                erased = eraseSomeRewrite rw
+            -- Just verify erasure succeeds
+            case erased of
+                _ := _ -> return ()
+                _ :| _ -> assertFailure "Expected simple rewrite"
+        ]
+
+    , testGroup "Type-Indexed E-Matching"
+        [ testCase "ematchI finds matches" $ do
+            let (matches, _) = runTExpr $ do
+                    c1 <- addIM (TInt 1)
+                    c2 <- addIM (TInt 2)
+                    _ <- addIM (TAdd c1 c2)
+                    rebuildIM
+                    eg <- getEGraphIM
+                    let db = eGraphToDatabaseI eg
+                        x :: PatternI TExpr 'TyInt
+                        x = "x"
+                        y :: PatternI TExpr 'TyInt
+                        y = "y"
+                        pat :: PatternI TExpr 'TyInt
+                        pat = patI (TAdd x y)
+                    return $ ematchI db pat
+            length matches @?= 1
+        ]
+
+    , testGroup "Indexed Equality Saturation"
+        [ testCase "runEqualitySaturationI applies rewrites" $ do
+            -- Build 1 + 2 and apply commutativity
+            let (finalEg, _) = runTExpr $ do
+                    c1 <- addIM (TInt 1)
+                    c2 <- addIM (TInt 2)
+                    _ <- addIM (TAdd c1 c2)
+                    rebuildIM
+                    eg <- getEGraphIM
+                    let x :: PatternI TExpr 'TyInt
+                        x = "x"
+                        y :: PatternI TExpr 'TyInt
+                        y = "y"
+                        rw = ruleI (patI (TAdd x y)) (patI (TAdd y x))
+                    return $ runEqualitySaturationI defaultBackoffScheduler [rw] eg
+            -- Just verify it runs without error
+            case finalEg of
+                EGraphI _ -> return ()
+        ]
+
+    , testGroup "Type Safety"
+        [ testCase "ill-typed rewrites don't compile (documented)" $ do
+            -- This demonstrates that the type system prevents ill-typed rewrites
+            -- The following would NOT compile:
+            -- badRule = patI (TInt 1) :=: patI (TBool True)
+            --
+            -- GHC would report:
+            --   Couldn't match type ''TyBool' with ''TyInt'
+            return ()
+
+        , testCase "mixed-type operations preserve indices" $ do
+            -- Build: if (1 == 2) then 3 else 4
+            let (cid, _) = runTExpr $ do
+                    c1 <- addIM (TInt 1)
+                    c2 <- addIM (TInt 2)
+                    cond <- addIM (TEq c1 c2)
+                    c3 <- addIM (TInt 3)
+                    c4 <- addIM (TInt 4)
+                    addIM (TIf cond c3 c4)
+            -- Verify the expression was added (6th class)
+            cid @?= 6
+        ]
+    ]
+

--- a/test/Singleton.hs
+++ b/test/Singleton.hs
@@ -1,0 +1,231 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-|
+Test module for singleton infrastructure.
+-}
+module Singleton where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Data.Equality.Utils.Singleton
+import Data.Equality.Utils.HList
+import Data.Functor.Identity
+
+-- | Test type universe
+data Ty = TyInt | TyBool | TyFunc Ty Ty
+    deriving (Eq, Show)
+
+-- | Singleton instances for Ty
+data instance Sing (t :: Ty) where
+    STyInt  :: Sing 'TyInt
+    STyBool :: Sing 'TyBool
+    STyFunc :: Sing a -> Sing b -> Sing ('TyFunc a b)
+
+-- Show instance for Sing Ty
+instance Show (Sing (t :: Ty)) where
+    show STyInt = "STyInt"
+    show STyBool = "STyBool"
+    show (STyFunc a b) = "STyFunc (" ++ show a ++ ") (" ++ show b ++ ")"
+
+
+-- | SingI instances for Ty
+instance SingI 'TyInt where
+    sing = STyInt
+
+instance SingI 'TyBool where
+    sing = STyBool
+
+instance (SingI a, SingI b) => SingI ('TyFunc a b) where
+    sing = STyFunc sing sing
+
+-- | SDecide instance for Ty
+instance SDecide Ty where
+    decEq STyInt STyInt = Just Refl
+    decEq STyBool STyBool = Just Refl
+    decEq (STyFunc a1 b1) (STyFunc a2 b2) = do
+        Refl <- decEq a1 a2
+        Refl <- decEq b1 b2
+        Just Refl
+    decEq _ _ = Nothing
+
+-- | SOrd instance for Ty (for testing Ord on SomeType)
+instance SOrd Ty where
+    sCompare STyInt STyInt = SEQ
+    sCompare STyInt _ = SLT
+    sCompare STyBool STyInt = SGT
+    sCompare STyBool STyBool = SEQ
+    sCompare STyBool (STyFunc _ _) = SLT
+    sCompare (STyFunc _ _) STyInt = SGT
+    sCompare (STyFunc _ _) STyBool = SGT
+    sCompare (STyFunc a1 b1) (STyFunc a2 b2) = case sCompare a1 a2 of
+        SLT -> SLT
+        SGT -> SGT
+        SEQ -> sCompare b1 b2
+
+-- | Test suite for singleton infrastructure
+singletonTests :: TestTree
+singletonTests = testGroup "Singleton Infrastructure"
+    [ testGroup "SingI"
+        [ testCase "sing @TyInt returns STyInt" $
+            show (sing :: Sing 'TyInt) @?= "STyInt"
+        , testCase "sing @TyBool returns STyBool" $
+            show (sing :: Sing 'TyBool) @?= "STyBool"
+        , testCase "sing @(TyFunc TyInt TyBool) returns correct structure" $
+            show (sing :: Sing ('TyFunc 'TyInt 'TyBool)) @?= "STyFunc (STyInt) (STyBool)"
+        ]
+    , testGroup "SDecide"
+        [ testCase "decEq STyInt STyInt = Just Refl" $
+            case decEq STyInt STyInt of
+                Just Refl -> return ()
+                Nothing -> assertFailure "Expected Just Refl"
+        , testCase "decEq STyBool STyBool = Just Refl" $
+            case decEq STyBool STyBool of
+                Just Refl -> return ()
+                Nothing -> assertFailure "Expected Just Refl"
+        , testCase "decEq STyInt STyBool = Nothing" $
+            decEq STyInt STyBool @?= Nothing
+        , testCase "decEq STyBool STyInt = Nothing" $
+            decEq STyBool STyInt @?= Nothing
+        , testCase "decEq on equal function types = Just Refl" $
+            case decEq (STyFunc STyInt STyBool) (STyFunc STyInt STyBool) of
+                Just Refl -> return ()
+                Nothing -> assertFailure "Expected Just Refl"
+        , testCase "decEq on different function types = Nothing" $
+            decEq (STyFunc STyInt STyBool) (STyFunc STyBool STyInt) @?= Nothing
+        ]
+    , testGroup "SomeType"
+        [ testCase "SomeType can hide type information" $ do
+            let intType = SomeType STyInt
+                boolType = SomeType STyBool
+            -- They're both SomeType Ty
+            withSomeType intType (\s -> show s @?= "STyInt")
+            withSomeType boolType (\s -> show s @?= "STyBool")
+        , testCase "fromSomeType recovers matching type" $ do
+            let intType = SomeType STyInt
+            case fromSomeType STyInt intType of
+                Just s -> show s @?= "STyInt"
+                Nothing -> assertFailure "Expected Just"
+        , testCase "fromSomeType returns Nothing for non-matching type" $ do
+            let intType = SomeType STyInt
+            case fromSomeType STyBool intType of
+                Nothing -> return ()
+                Just _ -> assertFailure "Expected Nothing"
+        , testCase "SomeType Eq: same types are equal" $
+            SomeType STyInt == SomeType STyInt @?= True
+        , testCase "SomeType Eq: different types are not equal" $
+            SomeType STyInt == SomeType STyBool @?= False
+        , testCase "SomeType Ord: ordering works" $ do
+            -- TyInt < TyBool < TyFunc
+            (SomeType STyInt < SomeType STyBool) @?= True
+            (SomeType STyBool < SomeType (STyFunc STyInt STyBool)) @?= True
+        ]
+    , testGroup "SingList"
+        [ testCase "singList @'[] returns SNil" $ do
+            let sl = singList :: SingList ('[] :: [Ty])
+            case sl of
+                SNil -> return ()
+        , testCase "singList @'[TyInt] returns SCons STyInt SNil" $ do
+            let sl = singList :: SingList '[ 'TyInt ]
+            case sl of
+                SCons STyInt SNil -> return ()
+        , testCase "singList @'[TyInt, TyBool] has correct structure" $ do
+            let sl = singList :: SingList '[ 'TyInt, 'TyBool ]
+            case sl of
+                SCons STyInt (SCons STyBool SNil) -> return ()
+        , testCase "sListLength SNil = 0" $
+            sListLength SNil @?= 0
+        , testCase "sListLength single element = 1" $
+            sListLength (SCons STyInt SNil) @?= 1
+        , testCase "sListLength two elements = 2" $
+            sListLength (SCons STyInt (SCons STyBool SNil)) @?= 2
+        ]
+    , testGroup "SingList equality"
+        [ testCase "decEqList on equal lists = Just Refl" $ do
+            let sl1 = SCons STyInt (SCons STyBool SNil)
+                sl2 = SCons STyInt (SCons STyBool SNil)
+            case decEqList sl1 sl2 of
+                Just Refl -> return ()
+                Nothing -> assertFailure "Expected Just Refl"
+        , testCase "decEqList on different lists = Nothing" $ do
+            let sl1 = SCons STyInt SNil
+                sl2 = SCons STyBool SNil
+            decEqList sl1 sl2 @?= Nothing
+        , testCase "decEqList on different lengths = Nothing" $ do
+            let sl1 = SCons STyInt SNil
+                sl2 = SCons STyInt (SCons STyBool SNil)
+            decEqList sl1 sl2 @?= Nothing
+        ]
+    , testGroup "Type-safe coercion with Refl"
+        [ testCase "Refl proof enables type-safe operations" $ do
+            -- This test demonstrates that Refl can be used for type-safe operations
+            let intSing1 = STyInt
+                intSing2 = STyInt
+            case decEq intSing1 intSing2 of
+                Just Refl -> do
+                    -- Here, GHC knows the types are equal
+                    let _sameSing :: Sing 'TyInt
+                        _sameSing = intSing2
+                    return ()
+                Nothing -> assertFailure "Expected Refl proof"
+        ]
+    , testGroup "HList"
+        [ testCase "HNil has length 0" $
+            hLength (HNil :: HList Identity '[]) @?= 0
+        , testCase "single element HList has length 1" $
+            hLength (Identity (42 :: Int) `HCons` HNil) @?= 1
+        , testCase "three element HList has length 3" $ do
+            let hlist = Identity (42 :: Int) `HCons`
+                        Identity True `HCons`
+                        Identity "hello" `HCons`
+                        HNil
+            hLength hlist @?= 3
+        , testCase "hLookup Here retrieves first element" $ do
+            let hlist = Identity (42 :: Int) `HCons`
+                        Identity True `HCons`
+                        HNil
+            runIdentity (hLookup Here hlist) @?= 42
+        , testCase "hLookup There Here retrieves second element" $ do
+            let hlist = Identity (42 :: Int) `HCons`
+                        Identity True `HCons`
+                        HNil
+            runIdentity (hLookup (There Here) hlist) @?= True
+        , testCase "hMap transforms all elements" $ do
+            -- hMap applies the same transformation to each element
+            let hlist = Identity (1 :: Int) `HCons`
+                        Identity True `HCons`
+                        HNil
+            -- Wrap in Maybe (works for all types)
+            let wrapped = hMap (\(Identity x) -> Just x) hlist
+            hLookup Here wrapped @?= Just (1 :: Int)
+            hLookup (There Here) wrapped @?= Just True
+        , testCase "hFoldr counts elements correctly" $ do
+            let hlist = Identity (1 :: Int) `HCons`
+                        Identity True `HCons`
+                        Identity "hello" `HCons`
+                        HNil
+            -- Count elements (ignores the actual value)
+            let count = hFoldr (\_ acc -> acc + 1) 0 hlist
+            count @?= (3 :: Int)
+        , testCase "HList Eq: equal lists" $ do
+            let hlist1 = Identity (42 :: Int) `HCons` Identity True `HCons` HNil
+                hlist2 = Identity (42 :: Int) `HCons` Identity True `HCons` HNil
+            (hlist1 == hlist2) @?= True
+        , testCase "HList Eq: unequal lists" $ do
+            let hlist1 = Identity (42 :: Int) `HCons` Identity True `HCons` HNil
+                hlist2 = Identity (43 :: Int) `HCons` Identity True `HCons` HNil
+            (hlist1 == hlist2) @?= False
+        , testCase "HList Ord works" $ do
+            let hlist1 = Identity (1 :: Int) `HCons` HNil
+                hlist2 = Identity (2 :: Int) `HCons` HNil
+            (hlist1 < hlist2) @?= True
+        ]
+    ]

--- a/test/SymExpr.hs
+++ b/test/SymExpr.hs
@@ -1,0 +1,459 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-|
+Test module for type-indexed symbolic expressions.
+
+This module preserves the original SymExpr GADT from the reference example
+and demonstrates how to use SymExprF (the base functor) with hegg's
+equality saturation infrastructure.
+
+The key types from the reference:
+- SymExpr: The original recursive GADT (not used directly by hegg)
+- SymExprF: The base functor suitable for equality saturation
+-}
+module SymExpr where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Data.Kind (Type)
+
+import Data.Equality.Utils.Singleton
+import Data.Equality.Utils.Untyped (ErasedLang(..), Untyped(..))
+import Data.Equality.Utils (Fix(..))
+import Data.Equality.Graph (ClassId)
+import Data.Equality.Graph.Indexed
+import Data.Equality.Graph.Monad.Indexed
+import Data.Equality.Matching.Indexed
+import Data.Equality.Matching.Pattern.Indexed
+import Data.Equality.Saturation.Rewrites.Indexed
+import Data.Equality.Saturation.Indexed
+import Data.Equality.Extraction.Indexed
+import Data.Equality.Language.Indexed ()
+import Data.Equality.Analysis.Indexed ()
+import Data.Equality.Saturation.Scheduler (defaultBackoffScheduler)
+
+--------------------------------------------------------------------------------
+-- Original SymExpr Types (preserved exactly from reference)
+--------------------------------------------------------------------------------
+
+-- | Phantom types representing the type-level tags
+data SymType = TyDouble | TyString
+  deriving (Show, Eq, Ord)
+
+-- | GADT for symbolic expressions with type-level tracking
+data SymExpr (t :: SymType) where
+  Constant :: Double -> SymExpr TyDouble
+  Symbol :: forall t. String -> SymExpr t
+  (:+:) :: forall t. SymExpr t -> SymExpr t -> SymExpr t
+  (:*:) :: SymExpr TyDouble -> SymExpr TyDouble -> SymExpr TyDouble
+  (:/:) :: SymExpr TyDouble -> SymExpr TyDouble -> SymExpr TyDouble
+
+deriving instance Show (SymExpr t)
+
+-- | Base functor for SymExpr, suitable for use with Fix and recursion schemes
+data SymExprF (t :: SymType) r where
+  ConstantF :: Double -> SymExprF TyDouble r
+  SymbolF :: forall t r. String -> SymExprF t r
+  (:++:) :: forall t r. r -> r -> SymExprF t r
+  (:**:) :: r -> r -> SymExprF TyDouble r
+  (://:) :: r -> r -> SymExprF TyDouble r
+
+deriving instance Show r => Show (SymExprF t r)
+deriving instance Functor (SymExprF t)
+deriving instance Foldable (SymExprF t)
+deriving instance Traversable (SymExprF t)
+
+-- | Fixed point of SymExprF (from reference)
+type Expr t = Fix (SymExprF t)
+
+-- | Example expressions (from reference)
+e1 :: Expr TyDouble
+e1 = Fix (Fix (ConstantF 10.0) :**: Fix (ConstantF 2.0)) -- 10 * 2
+
+e2 :: Expr TyDouble
+e2 = Fix (Fix (ConstantF 20.0) ://: Fix (ConstantF 2.0)) -- 20 / 2
+
+e3 :: Expr TyDouble
+e3 = Fix (Fix (ConstantF 5.0) :++: Fix (ConstantF 3.0)) -- 5 + 3
+
+e4 :: Expr TyDouble
+e4 = Fix (Fix (Fix (SymbolF "x") :**: Fix (ConstantF 2.0)) ://: Fix (ConstantF 2.0)) -- (x*2)/2
+
+--------------------------------------------------------------------------------
+-- Singleton Infrastructure for SymType (required by hegg)
+--------------------------------------------------------------------------------
+
+-- | Singleton types for SymType
+data instance Sing (t :: SymType) where
+    STyDouble :: Sing 'TyDouble
+    STyString :: Sing 'TyString
+
+instance Show (Sing (t :: SymType)) where
+    show STyDouble = "STyDouble"
+    show STyString = "STyString"
+
+instance SingI 'TyDouble where
+    sing = STyDouble
+
+instance SingI 'TyString where
+    sing = STyString
+
+instance SDecide SymType where
+    decEq STyDouble STyDouble = Just Refl
+    decEq STyString STyString = Just Refl
+    decEq _ _ = Nothing
+
+instance SOrd SymType where
+    sCompare STyDouble STyDouble = SEQ
+    sCompare STyDouble STyString = SLT
+    sCompare STyString STyDouble = SGT
+    sCompare STyString STyString = SEQ
+
+--------------------------------------------------------------------------------
+-- Additional Instances for SymExprF (required by hegg's Language constraint)
+--------------------------------------------------------------------------------
+
+-- | Eq instance for SymExprF
+instance Eq r => Eq (SymExprF t r) where
+    ConstantF d1 == ConstantF d2 = d1 == d2
+    SymbolF s1 == SymbolF s2 = s1 == s2
+    (a1 :++: b1) == (a2 :++: b2) = a1 == a2 && b1 == b2
+    (a1 :**: b1) == (a2 :**: b2) = a1 == a2 && b1 == b2
+    (a1 ://: b1) == (a2 ://: b2) = a1 == a2 && b1 == b2
+    _ == _ = False
+
+-- | Ord instance for SymExprF (required for Language constraint)
+instance Ord r => Ord (SymExprF t r) where
+    compare (ConstantF d1) (ConstantF d2) = compare d1 d2
+    compare (SymbolF s1) (SymbolF s2) = compare s1 s2
+    compare (a1 :++: b1) (a2 :++: b2) = compare (a1, b1) (a2, b2)
+    compare (a1 :**: b1) (a2 :**: b2) = compare (a1, b1) (a2, b2)
+    compare (a1 ://: b1) (a2 ://: b2) = compare (a1, b1) (a2, b2)
+    compare x y = compare (tag x) (tag y)
+      where
+        tag :: SymExprF d s -> Int
+        tag ConstantF{} = 0
+        tag SymbolF{} = 1
+        tag (:++:){} = 2
+        tag (:**:){} = 3
+        tag (://:){} = 4
+
+--------------------------------------------------------------------------------
+-- Cost Function for Extraction
+--------------------------------------------------------------------------------
+
+-- | Cost function: prefer simpler expressions
+costI :: CostFunction (ErasedLang SymExprF) Int
+costI (ErasedLang (Untyped node)) = case node of
+    ConstantF _ -> 1
+    SymbolF _ -> 1
+    _ :++: c2 -> c2 + 2
+    c1 :**: c2 -> c1 + c2 + 3
+    c1 ://: c2 -> c1 + c2 + 4
+
+--------------------------------------------------------------------------------
+-- Rewrite Rules
+--------------------------------------------------------------------------------
+
+-- | Algebraic rewrite rules for symbolic simplification
+rewritesI :: [SomeRewrite () SymExprF]
+rewritesI =
+    [ -- Commutativity of multiplication
+      ruleI (patI (("x" :: PatternI SymExprF 'TyDouble) :**: "y"))
+            (patI (("y" :: PatternI SymExprF 'TyDouble) :**: "x"))
+
+    , -- Associativity of multiplication: (x * y) * z = x * (y * z)
+      ruleI (patI (patI (("x" :: PatternI SymExprF 'TyDouble) :**: "y") :**: "z"))
+            (patI ("x" :**: patI (("y" :: PatternI SymExprF 'TyDouble) :**: "z")))
+
+    , -- Identity: x * 1 = x
+      ruleI (patI (("x" :: PatternI SymExprF 'TyDouble) :**: patI (ConstantF 1))) "x"
+
+    , -- Identity: 1 * x = x
+      ruleI (patI (patI (ConstantF 1) :**: ("x" :: PatternI SymExprF 'TyDouble))) "x"
+
+    , -- Zero: x * 0 = 0
+      ruleI (patI (("x" :: PatternI SymExprF 'TyDouble) :**: patI (ConstantF 0))) (patI (ConstantF 0))
+
+    , -- Zero: 0 * x = 0
+      ruleI (patI (patI (ConstantF 0) :**: ("x" :: PatternI SymExprF 'TyDouble))) (patI (ConstantF 0))
+
+    , -- Self-division: x / x = 1
+      ruleI (patI (("x" :: PatternI SymExprF 'TyDouble) ://: "x")) (patI (ConstantF 1))
+
+    , -- Division identity: x / 1 = x
+      ruleI (patI (("x" :: PatternI SymExprF 'TyDouble) ://: patI (ConstantF 1))) "x"
+
+    , -- Division associativity: (a * b) / c = a * (b / c)
+      ruleI (patI (patI (("a" :: PatternI SymExprF 'TyDouble) :**: "b") ://: "c"))
+            (patI ("a" :**: patI (("b" :: PatternI SymExprF 'TyDouble) ://: "c")))
+
+    , -- Division by multiplication: (a / b) / c = a / (b * c)
+      ruleI (patI (patI (("a" :: PatternI SymExprF 'TyDouble) ://: "b") ://: "c"))
+            (patI ("a" ://: patI (("b" :: PatternI SymExprF 'TyDouble) :**: "c")))
+    ]
+
+--------------------------------------------------------------------------------
+-- Helper Functions
+--------------------------------------------------------------------------------
+
+type SymExprGraph = EGraphI () SymExprF
+
+runSymExpr :: EGraphIM () SymExprF a -> (a, SymExprGraph)
+runSymExpr = egraphI
+
+--------------------------------------------------------------------------------
+-- Test Suite
+--------------------------------------------------------------------------------
+
+symExprTests :: TestTree
+symExprTests = testGroup "Type-Indexed Symbolic Expressions"
+    [ testGroup "Singleton Infrastructure"
+        [ testCase "sing @TyDouble returns STyDouble" $
+            show (sing :: Sing 'TyDouble) @?= "STyDouble"
+
+        , testCase "sing @TyString returns STyString" $
+            show (sing :: Sing 'TyString) @?= "STyString"
+
+        , testCase "decEq STyDouble STyDouble = Just Refl" $
+            case decEq STyDouble STyDouble of
+                Just Refl -> return ()
+                Nothing -> assertFailure "Expected Just Refl"
+
+        , testCase "decEq STyDouble STyString = Nothing" $
+            decEq STyDouble STyString @?= Nothing
+
+        , testCase "SOrd: TyDouble < TyString" $
+            case sCompare STyDouble STyString of
+                SLT -> return ()
+                _ -> assertFailure "Expected SLT"
+        ]
+
+    , testGroup "Original SymExpr GADT"
+        [ testCase "Constant creates TyDouble expression" $ do
+            let expr :: SymExpr TyDouble
+                expr = Constant 42.0
+            case expr of
+                Constant d -> d @?= 42.0
+
+        , testCase "Symbol is polymorphic" $ do
+            let exprD :: SymExpr TyDouble
+                exprD = Symbol "x"
+                exprS :: SymExpr TyString
+                exprS = Symbol "y"
+            case (exprD, exprS) of
+                (Symbol sx, Symbol sy) -> do
+                    sx @?= "x"
+                    sy @?= "y"
+
+        , testCase "(:+:) is polymorphic" $ do
+            let expr :: SymExpr TyDouble
+                expr = Symbol "x" :+: Constant 1.0
+            case expr of
+                _ :+: _ -> return ()
+
+        , testCase "(:*:) restricted to TyDouble" $ do
+            let expr :: SymExpr TyDouble
+                expr = Constant 2.0 :*: Constant 3.0
+            case expr of
+                _ :*: _ -> return ()
+        ]
+
+    , testGroup "SymExprF Base Functor"
+        [ testCase "ConstantF creates TyDouble functor" $ do
+            let node :: SymExprF 'TyDouble Int
+                node = ConstantF 42.0
+            case node of
+                ConstantF d -> d @?= 42.0
+
+        , testCase "SymbolF is polymorphic" $ do
+            let nodeD :: SymExprF 'TyDouble Int
+                nodeD = SymbolF "x"
+                nodeS :: SymExprF 'TyString Int
+                nodeS = SymbolF "y"
+            case (nodeD, nodeS) of
+                (SymbolF sx, SymbolF sy) -> do
+                    sx @?= "x"
+                    sy @?= "y"
+
+        , testCase "Functor instance works" $ do
+            let node :: SymExprF 'TyDouble Int
+                node = 1 :**: 2
+                mapped = fmap (+10) node
+            case mapped of
+                11 :**: 12 -> return ()
+                _ -> assertFailure "Expected mapped values"
+        ]
+
+    , testGroup "EGraphI Operations"
+        [ testCase "addI adds constant" $ do
+            let (cid, _) = runSymExpr $ addIM (ConstantF 42.0)
+            cid @?= 1
+
+        , testCase "addI adds symbol" $ do
+            let (cid, _) = runSymExpr $ addIM (SymbolF @'TyDouble "x")
+            cid @?= 1
+
+        , testCase "addI builds compound expression" $ do
+            let (cid, _) = runSymExpr $ do
+                    c1 <- addIM (SymbolF @'TyDouble "x")
+                    c2 <- addIM (ConstantF 2.0)
+                    addIM (c1 :**: c2)
+            cid @?= 3
+
+        , testCase "identical expressions share e-class" $ do
+            let (result, _) = runSymExpr $ do
+                    c1 <- addIM (ConstantF 42.0)
+                    c2 <- addIM (ConstantF 42.0)
+                    return (c1, c2)
+            fst result @?= snd result
+        ]
+
+    , testGroup "Pattern Matching"
+        [ testCase "patI creates non-variable patterns" $ do
+            let p :: PatternI SymExprF 'TyDouble
+                p = patI (ConstantF 42.0)
+            case p of
+                NonVariablePatternI _ -> return ()
+                _ -> assertFailure "Expected NonVariablePatternI"
+
+        , testCase "string literal creates variable patterns" $ do
+            let p :: PatternI SymExprF 'TyDouble
+                p = "x"
+            case p of
+                VariablePatternI "x" -> return ()
+                _ -> assertFailure "Expected VariablePatternI"
+
+        , testCase "nested patterns work" $ do
+            let p :: PatternI SymExprF 'TyDouble
+                p = patI ("x" :**: patI (ConstantF 2.0))
+            case p of
+                NonVariablePatternI _ -> return ()
+                _ -> assertFailure "Expected NonVariablePatternI"
+        ]
+
+    , testGroup "Algebraic Rewrites"
+        [ testCase "commutativity: multiplication x * y = y * x" $ do
+            let (matches, _) = runSymExpr $ do
+                    cx <- addIM (SymbolF @'TyDouble "x")
+                    c2 <- addIM (ConstantF 2.0)
+                    cxy <- addIM (cx :**: c2)
+                    rebuildIM
+                    eg <- getEGraphIM
+                    let eg' = runEqualitySaturationI defaultBackoffScheduler rewritesI eg
+                    put eg'
+                    cyx <- addIM (c2 :**: cx)
+                    rebuildIM
+                    eg'' <- getEGraphIM
+                    let r1 = findI eg'' cxy
+                        r2 = findI eg'' cyx
+                    return (r1, r2)
+            fst matches @?= snd matches
+
+        , testCase "identity: x * 1 = x" $ do
+            let (result, _) = runSymExpr $ do
+                    cx <- addIM (SymbolF @'TyDouble "x")
+                    c1 <- addIM (ConstantF 1.0)
+                    cExpr <- addIM (cx :**: c1)
+                    rebuildIM
+                    eg <- getEGraphIM
+                    let eg' = runEqualitySaturationI defaultBackoffScheduler rewritesI eg
+                    put eg'
+                    let r1 = findI eg' cx
+                        r2 = findI eg' cExpr
+                    return (r1, r2)
+            fst result @?= snd result
+
+        , testCase "self-division: x / x = 1" $ do
+            let (result, _) = runSymExpr $ do
+                    cx <- addIM (SymbolF @'TyDouble "x")
+                    cExpr <- addIM (cx ://: cx)
+                    c1 <- addIM (ConstantF 1.0)
+                    rebuildIM
+                    eg <- getEGraphIM
+                    let eg' = runEqualitySaturationI defaultBackoffScheduler rewritesI eg
+                    put eg'
+                    let r1 = findI eg' cExpr
+                        r2 = findI eg' c1
+                    return (r1, r2)
+            fst result @?= snd result
+
+        , testCase "zero: x * 0 = 0" $ do
+            let (result, _) = runSymExpr $ do
+                    cx <- addIM (SymbolF @'TyDouble "x")
+                    c0 <- addIM (ConstantF 0.0)
+                    cExpr <- addIM (cx :**: c0)
+                    rebuildIM
+                    eg <- getEGraphIM
+                    let eg' = runEqualitySaturationI defaultBackoffScheduler rewritesI eg
+                    put eg'
+                    let r1 = findI eg' cExpr
+                        r2 = findI eg' c0
+                    return (r1, r2)
+            fst result @?= snd result
+        ]
+
+    , testGroup "Complex Simplification"
+        [ testCase "(x * 2) / 2 simplifies to x (using e4 pattern)" $ do
+            -- This mirrors e4 from the reference: (x*2)/2
+            let (rootId, eg) = runSymExpr $ do
+                    cx <- addIM (SymbolF @'TyDouble "x")
+                    c2 <- addIM (ConstantF 2.0)
+                    cMul <- addIM (cx :**: c2)
+                    c2' <- addIM (ConstantF 2.0)
+                    addIM (cMul ://: c2')
+
+                eg' = runEqualitySaturationI defaultBackoffScheduler rewritesI eg
+                result = extractBestI eg' costI rootId
+
+            case result of
+                Fix (ErasedLang (Untyped (SymbolF "x"))) -> return ()
+                _ -> assertFailure $ "Expected SymbolF x, got: " ++ show result
+        ]
+
+    , testGroup "Type Safety"
+        [ testCase "type indices prevent ill-typed rewrites" $ do
+            -- The following would NOT compile:
+            -- badRule :: RewriteI () SymExprF 'TyDouble
+            -- badRule = patI (ConstantF 1.0) :=: patI (SymbolF @'TyString "x")
+            return ()
+
+        , testCase "polymorphic operations work across types" $ do
+            let nodeD :: SymExprF 'TyDouble ClassId
+                nodeD = SymbolF "x"
+                nodeS :: SymExprF 'TyString ClassId
+                nodeS = SymbolF "y"
+                addD :: SymExprF 'TyDouble ClassId
+                addD = 1 :++: 2
+            case (nodeD, nodeS, addD) of
+                (SymbolF _, SymbolF _, _ :++: _) -> return ()
+
+        , testCase "restricted operations maintain type safety" $ do
+            let node :: SymExprF 'TyDouble ClassId
+                node = 1 :**: 2
+            -- The following would NOT compile:
+            -- let invalid :: SymExprF 'TyString ClassId
+            --     invalid = 1 :**: 2
+            case node of
+                _ :**: _ -> return ()
+        ]
+    ]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -12,6 +12,9 @@ import Sym
 import Lambda
 import SimpleSym
 import T32
+import Singleton
+import Indexed
+import SymExpr
 
 import qualified T1
 import qualified T2
@@ -21,11 +24,14 @@ import qualified VizDot
 # endif
 
 tests :: TestTree
-tests =testGroup "Tests"
+tests = testGroup "Tests"
     [ symTests
     , lambdaTests
     , simpleSymTests
     , invariants
+    , singletonTests
+    , indexedTests
+    , symExprTests
     , testCase "T1" (T1.main `catch` (\(e :: SomeException) -> assertFailure (show e)))
     , testCase "T2" (T2.main `catch` (\(e :: SomeException) -> assertFailure (show e)))
     , testCase "T3" (T3.main `catch` (\(e :: SomeException) -> assertFailure (show e)))


### PR DESCRIPTION
In the documentation for `hegg` we find the example of a simple expression language:

```haskell
data SymExpr a = Const Double
               | Symbol String
               | a :+: a
               | a :*: a
               | a :/: a
               deriving (Eq, Ord, Show, Functor, Foldable, Traversable)
infix 6 :+:
infix 7 :*:, :/:

e1 :: Fix SymExpr
e1 = Fix (Fix (Fix (Symbol "x") :*: Fix (Const 2)) :/: (Fix (Const 2))) -- (x*2)/2
```

The purpose of this PR is to allow rewrite rules to be directly apply to type-indexed expression languages, such as:

```haskell
-- | Phantom types representing the type-level tags
data SymType = TyDouble | TyString
  deriving (Show)

-- | GADT for symbolic expressions with type-level tracking
data SymExpr (t :: SymType) where
  Constant :: Double -> SymExpr TyDouble
  Symbol :: forall t. String -> SymExpr t
  (:+:) :: forall t. SymExpr t -> SymExpr t -> SymExpr t
  (:*:) :: SymExpr TyDouble -> SymExpr TyDouble -> SymExpr TyDouble
  (:/:) :: SymExpr TyDouble -> SymExpr TyDouble -> SymExpr TyDouble

deriving instance Show (SymExpr t)

-- | Base functor for SymExpr, suitable for use with Fix and recursion schemes
data SymExprF (t :: SymType) r where
  ConstantF :: Double -> SymExprF TyDouble r
  SymbolF :: forall t r. String -> SymExprF t r
  (:++:) :: forall t r. r -> r -> SymExprF t r
  (:**:) :: r -> r -> SymExprF TyDouble r
  (://:) :: r -> r -> SymExprF TyDouble r

deriving instance (Show r) => Show (SymExprF t r)

deriving instance Functor (SymExprF t)

deriving instance Foldable (SymExprF t)

deriving instance Traversable (SymExprF t)

-- | Fixed point of SymExprF
type Expr t = Fix (SymExprF t)

e1 :: Expr TyDouble
e1 = Fix (Fix (Fix (SymbolF "x") :**: Fix (ConstantF 2.0)) ://: Fix (ConstantF 2.0)) -- (x*2)/2
```