### PR TITLE
Support capture-preserving computed rewrite patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@
   to a right-hand-side computed by a Haskell function of the matching
   substitution and `EGraph`.
 
+* Add `ComputePattern lhs build` for computed RHS patterns that preserve LHS
+  captures. The existing expression-returning `:=>` and `RewriteFun` API remains
+  available.
+* Export `PatternRewriteFun`, `rewriteLhs`, and `rewriteRhs`, including from
+  `Data.Equality.Saturation`, for custom saturation runners. Reject unbound
+  RHS variables before insertion.
+* Include class nodes and analysis in fixed-point detection, so count-stable
+  changes can enable another rewrite round.
+* Add a symbolic constant-combination example and computed-rewrite contract
+  tests to the existing test suite.
 
 ## 0.6.0.0 -- 2024-07-13
 

--- a/README.md
+++ b/README.md
@@ -300,6 +300,53 @@ the equality-graphs and other equality-things (such as e-matching) available.
 For example, using just the e-graphs from `Data.Equality.Graph` to improve GHC's
 pattern match checker (https://gitlab.haskell.org/ghc/ghc/-/issues/19272).
 
+## Computed rewrites
+
+Computed rewrites construct a replacement from a particular match. The existing
+`lhs :=> build` form uses `RewriteFun`: its builder receives a map of variable
+names to `MatchInfo` and returns an optional expression (`Fix l`).
+
+Use `ComputePattern lhs build` to construct a replacement that retains matched
+e-classes as children. Its builder has the same read-only inputs as a rewrite
+condition and returns an optional **pattern**:
+
+```haskell
+type PatternRewriteFun a l =
+    VarsState -> Subst -> EGraph a l -> Maybe (Pattern l)
+```
+
+`Nothing` declines the match without inserting anything. `Just rhs` inserts
+the pattern and equates it with the matched root. RHS variables reuse the
+LHS captures. Computed rewrites compose with `:|` conditions and ordinary `:=`
+rules.
+
+For integer expressions, this rule combines known constants in `(x + a) + b`
+while keeping `x` as a capture:
+
+```haskell
+combineConstants :: Rewrite (Maybe Integer) Expr
+combineConstants = ComputePattern (pat $ Add (pat $ Add "x" "a") "b") $ \vars subst graph -> do
+    let value name = graph ^. _class (findSubst (findVarName vars name) subst) . _data
+    a <- value "a"
+    b <- value "b"
+    pure $ pat $ Add "x" (pat $ Number $ a + b)
+```
+
+For example, `(x + 2) + 3` becomes `x + 5` without knowing the value of `x`.
+The builder refuses if either constant is unknown. The complete language,
+analysis, and executable example are in [ComputedRewrites.hs](test/ComputedRewrites.hs).
+
+The standard runner checks guards during matching and again before application,
+then evaluates builders against its current graph. Structural or analysis
+changes can enable another round; retries remain subject to the existing
+scheduler policy and 30-round limit. `rewriteLhs` and `rewriteRhs` support custom
+runners that need their own inspection graph or capture insertion policy. See the
+[contract and custom runner integration notes](doc/computed-rewrites.md).
+
+For analysis-wide constant materialization, the existing `Analysis.modifyA`
+hook remains sufficient; computed rewrites are useful when construction
+depends on a particular pattern match.
+
 ## Debugging Rewrite Rules
 
 To debug rewrite rules when doing equality saturation, wrap the `Scheduler`
@@ -327,4 +374,3 @@ open hegg-test.eventlog.html
 ```
 cabal test hegg-test --enable-coverage --enable-library-coverage
 ```
-

--- a/doc/computed-rewrites.md
+++ b/doc/computed-rewrites.md
@@ -1,0 +1,89 @@
+# Computed rewrite patterns
+
+`ComputePattern lhs build` extends computed rewrites with RHS patterns that
+retain the matched e-classes. The existing `lhs :=> build` form and `RewriteFun`
+type remain available: they receive a map of variable names to `MatchInfo` and
+return an optional expression (`Fix l`).
+
+The pattern builder uses the existing `Pattern`, substitution, analysis, and
+insertion machinery:
+
+```haskell
+type PatternRewriteFun a l =
+    VarsState -> Subst -> EGraph a l -> Maybe (Pattern l)
+
+rewriteLhs :: Rewrite a l -> Pattern l
+rewriteRhs :: Traversable l
+           => Rewrite a l -> VarsState -> Subst -> EGraph a l
+           -> Maybe (Pattern l)
+```
+
+`ComputePattern` takes a LHS pattern and a `PatternRewriteFun`. Its builder can
+inspect analysis or nodes using the same inputs as a `:|` condition. A capture
+named `"x"` is found with
+`findSubst (findVarName vars "x") subst`; `_class` resolves its representative
+in the supplied graph. Returning `"x"` in the RHS reuses that capture. Returning
+`pat (Add "x" (pat (Number n)))` builds an addition with a computed constant and
+the same captured child. No extraction, copied expression, mutable builder,
+new pattern language, or additional dependency is needed. The `rewriteRhs`
+helper also handles static rewrites and the existing expression builders,
+converting their expressions into patterns without variables.
+
+## Contract
+
+* `Nothing` means that this match is not applicable. No nodes or merges result
+  from that refusal. A builder has no graph state to mutate.
+* A successful RHS must be semantically equivalent to the LHS under the facts
+  proved by the builder and its conditions. The graph cannot retract the
+  equality if later information invalidates an assumption. Builders must not
+  guess from unknown facts or choose arbitrarily between conflicting facts.
+* Every RHS variable must be bound by the LHS. `rewriteRhs` validates the whole
+  pattern before insertion. An unbound name is a malformed-rule error, not a
+  refusal. This is not a general exception-handling or rollback facility for
+  bugs in language analyses.
+* The standard runner filters matches by their `:|` conditions using the
+  matching snapshot before updating scheduler statistics. Before application,
+  `rewriteRhs` rechecks conditions outside-in against the current graph and
+  short-circuits before RHS construction. Static and both forms of computed
+  RHS use the same insertion and root merge.
+* Builders see the standard runner's current graph immediately before an
+  application. Earlier applications in the round may have merged captures.
+  Resolve IDs relative to that graph; parent analysis and congruence may still
+  await rebuilding. Rules needing complete facts can refuse and be retried as
+  subsequent rounds run after rebuild.
+* A builder should return the same pattern for unchanged semantic evidence.
+  Hash-consing and merging then make repeated application idempotent. Fresh
+  payloads or endlessly growing equivalent patterns can consume the runner's
+  30-round limit, just like expansive static rules.
+* The runner rebuilds after each round. Callers that need fully repaired facts
+  for the first round should rebuild pending changes before invoking it.
+  It checks class nodes and analysis as well as memo/class counts before stopping.
+  Refusals are not cached. Scheduling counts matches that pass their `:|`
+  conditions, including those whose builder subsequently refuses. The existing
+  backoff policy is preserved: at a fixed point, bans are cleared for another
+  round only when no rules matched. If other rules still match without making
+  progress, the runner can stop while a rule remains banned. Custom runners own
+  their scheduling and retry policy.
+
+## Combining constants
+
+[ComputedRewrites.hs](../test/ComputedRewrites.hs) includes a small integer
+language and a `combineConstants` rule for `(x + a) + b`. The builder reads
+known values for `a` and `b` from analysis, computes their sum, and returns
+`x + Number (a + b)`. The expression captured by `x` is reused unchanged, even
+when its value is unknown. For example, `(x + 2) + 3` becomes `x + 5`.
+If either constant is unknown, the builder returns `Nothing`.
+
+This example demonstrates computed construction that preserves a capture.
+The existing `Analysis.modifyA` hook remains suitable for materializing
+constants throughout an e-graph.
+
+## Custom runners
+
+Use `rewriteLhs` for matching and `rewriteRhs` to evaluate a match against the
+chosen inspection graph. For `Just rhs`, resolve captures against the current
+graph, insert the pattern, and merge its result with the matched root according
+to the runner's own policy. Resolve inspection IDs in the graph being inspected:
+a representative introduced by later mutations may not exist in an earlier
+snapshot. Custom runners remain responsible for rebuilding, scheduling, and
+retrying matches when relevant facts change.

--- a/hegg.cabal
+++ b/hegg.cabal
@@ -40,6 +40,7 @@ copyright:          Copyright (C) 2022 Rodrigo Mesquita
 category:           Data
 extra-doc-files:    CHANGELOG.md
                     README.md
+                    doc/computed-rewrites.md
 
 source-repository head
     type: git
@@ -118,7 +119,8 @@ test-suite hegg-test
     hs-source-dirs:   test
     main-is:          Test.hs
     other-modules:    Computed, Invariants, Sym, Lambda, SimpleSym,
-                      T1, T2, T3, T32, T45, T51
+                      T1, T2, T3, T32, T45, T51,
+                      ComputedRewrites
     if flag(vizdot)
         other-modules: VizDot
         cpp-options:  -DVIZDOT

--- a/src/Data/Equality/Saturation.hs
+++ b/src/Data/Equality/Saturation.hs
@@ -29,7 +29,7 @@ module Data.Equality.Saturation
       -- * Re-exports for equality saturation
 
       -- ** Writing rewrite rules
-    , Rewrite(..), RewriteCondition
+    , Rewrite(..), RewriteCondition, PatternRewriteFun, rewriteLhs, rewriteRhs
 
       -- ** Writing cost functions
       --
@@ -45,7 +45,6 @@ module Data.Equality.Saturation
     ) where
 
 import qualified Data.IntMap.Strict as IM
-import qualified Data.Map.Strict as M
 
 import Control.Monad
 
@@ -101,12 +100,18 @@ equalitySaturation' schd expr rewrites cost = egraph $ do
 
 -- | Run equality saturation on an e-graph by non-destructively applying all
 -- given rewrite rules until saturation (using the given 'Scheduler')
+--
+-- Rebuild after each round of applications.
+-- A fixed point requires unchanged class nodes and analysis as well as stable
+-- node/class counts. Execution is bounded to 30 rounds. A computed builder
+-- returning 'Nothing' may be called again as rounds continue, subject to the
+-- scheduler's bans and the iteration limit.
 runEqualitySaturation :: forall a l schd
                        . (Analysis a l, Language l, Scheduler l schd)
                       => schd                -- ^ Scheduler to use
                       -> [Rewrite a l]       -- ^ List of rewrite rules
                       -> EGraphM a l ()
-runEqualitySaturation schd rewrites = runEqualitySaturation' 0 mempty where -- Start at iteration 0
+runEqualitySaturation schd rewrites = runEqualitySaturation' 0 mempty where
 
   -- Take map each rewrite rule to stats on its usage so we can do
   -- backoff scheduling. Each rewrite rule is assigned an integer
@@ -142,6 +147,9 @@ runEqualitySaturation schd rewrites = runEqualitySaturation' 0 mempty where -- S
       let structChanged = G.sizeNM afterMemo /= G.sizeNM beforeMemo
                        || IM.size afterClasses /= IM.size beforeClasses
           saturated = not structChanged
+                   -- Builders may become applicable after analysis changes
+                   -- or pruning replaces nodes without changing either count.
+                   && IM.isSubmapOfBy sameClass beforeClasses afterClasses
           -- Only consider retrying if no rules matched at all (likely because
           -- they're all banned). If rules matched but didn't add new structure,
           -- unbanning more rules probably won't help.
@@ -158,6 +166,10 @@ runEqualitySaturation schd rewrites = runEqualitySaturation' 0 mempty where -- S
           -- There's more to be done.
          | otherwise -> runEqualitySaturation' (i+1) newStats
 
+  sameClass :: EClass a l -> EClass a l -> Bool
+  sameClass before after = eClassData before == eClassData after
+                       && eClassNodes before == eClassNodes after
+
   -- | Match a rewrite rule against the e-graph database.
   -- For conditional rewrites, we accumulate all conditions and filter matches
   -- by them BEFORE updating scheduler stats. This ensures the backoff scheduler
@@ -169,8 +181,7 @@ runEqualitySaturation schd rewrites = runEqualitySaturation' 0 mempty where -- S
       -- Accumulate conditions while recursing through conditional rewrites
       go :: [RewriteCondition a l] -> Rewrite a l -> ([Match], IM.IntMap (Stat l schd), VarsState)
       go conds (rw' :| cond) = go (cond:conds) rw'
-      go conds (lhs :=> _) = doPattern conds lhs
-      go conds (lhs := _) = doPattern conds lhs
+      go conds base = doPattern conds (rewriteLhs base)
 
       doPattern conds lhs = do
           let (lhs_query, varsState) = compileToQuery lhs
@@ -204,63 +215,18 @@ runEqualitySaturation schd rewrites = runEqualitySaturation' 0 mempty where -- S
           all (\cond -> cond vss subst egr) conds
 
   applyMatchesRhs :: (Rewrite a l, Match, VarsState) -> EGraphM a l ()
-  applyMatchesRhs =
-      \case
-          (rw :| cond, m@(Match subst _), vss) -> do
-              -- If the rewrite condition is satisfied, applyMatchesRhs on the rewrite rule.
-              egr <- get
-              when (cond vss subst egr) $
-                 applyMatchesRhs (rw, m, vss)
+  applyMatchesRhs (rw, Match subst eclass, vss) = do
+      egr <- get
+      forM_ (rewriteRhs rw vss subst egr) $ \rhs -> do
+          eclass' <- reprPat vss subst rhs
+          -- Preserve the representative choice of static variable RHSs.
+          void $ case rhs of
+              VariablePattern _ -> merge eclass' eclass
+              NonVariablePattern _ -> merge eclass eclass'
 
-          (_ := VariablePattern v, Match subst eclass, vss) -> do
-              -- rhs is equal to a variable, simply merge class where lhs
-              -- pattern was found (@eclass@) and the eclass the pattern
-              -- variable matched (@lookup v subst@)
-              let n = findSubst (findVarName vss v) subst
-              _ <- merge n eclass
-              return ()
-
-          (_ := NonVariablePattern rhs, Match subst eclass, vss) -> do
-              -- rhs is (at the top level) a non-variable pattern, so substitute
-              -- all pattern variables in the pattern and create a new e-node (and
-              -- e-class that represents it), then merge the e-class of the
-              -- substituted rhs with the class that matched the left hand side
-              eclass' <- reprPat vss subst rhs
-              _ <- merge eclass eclass'
-              return ()
-
-          (_ :=> f, Match subst eclass, vss) -> do
-              egr <- get
-              let matchCtx = buildMatchContext vss subst egr
-              case f matchCtx of
-                Just rhs -> do
-                  eclass' <- reprExpr rhs
-                  _ <- merge eclass eclass'
-                  return ()
-                Nothing ->
-                  return ()
-
-  -- | Build the match context mapping variable names to their matched class info
-  buildMatchContext :: VarsState -> Subst -> G.EGraph a l -> M.Map String (MatchInfo a l)
-  buildMatchContext vss subst egr =
-      M.mapWithKey lookupInfo (varNames vss)
-    where
-      lookupInfo :: String -> Var -> MatchInfo a l
-      lookupInfo _name var =
-          let classId = findSubst var subst
-              canonId = G.find classId egr
-              eclass  = egr ^. _class canonId
-          in MatchInfo (eclass ^. _data) (eclass ^. _nodes)
-
-  -- | Represent a pattern in the e-graph given substitutions
-  reprPat :: VarsState -> Subst -> l (Pattern l) -> EGraphM a l ClassId
-  reprPat vss subst = add . Node <=< traverse \case
-      VariablePattern v -> pure $
-          findSubst (findVarName vss v) subst
-      NonVariablePattern p -> reprPat vss subst p
-
-  -- | Represent an expression (Fix l) in the e-graph
-  reprExpr :: Fix l -> EGraphM a l ClassId
-  reprExpr (Fix e) = add . Node =<< traverse reprExpr e
+  -- | Static and computed replacements share capture resolution and insertion.
+  reprPat :: VarsState -> Subst -> Pattern l -> EGraphM a l ClassId
+  reprPat vss subst = \case
+      VariablePattern v -> gets $ G.find (findSubst (findVarName vss v) subst)
+      NonVariablePattern p -> add . Node =<< traverse (reprPat vss subst) p
 {-# INLINEABLE runEqualitySaturation #-}
-

--- a/src/Data/Equality/Saturation/Rewrites.hs
+++ b/src/Data/Equality/Saturation/Rewrites.hs
@@ -12,15 +12,20 @@ module Data.Equality.Saturation.Rewrites
     , RewriteCondition
     , RewriteFun
     , MatchInfo(..)
+    , PatternRewriteFun
+    , rewriteLhs
+    , rewriteRhs
     ) where
 
 import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 
 import Data.Equality.Graph
+import Data.Equality.Graph.Lens
 import Data.Equality.Matching
 import Data.Equality.Matching.Database
-import Data.Equality.Utils (Fix)
+import Data.Equality.Utils (Fix, cata)
 
 -- | A rewrite rule that might have conditions for being applied
 --
@@ -80,6 +85,9 @@ data Rewrite anl lang
     -- The 'MatchInfo' interface ensures computed rewrites can only inspect
     -- the matched e-classes, not arbitrary e-graph structure. This makes it
     -- easier to write confluent rewrites.
+    | ComputePattern !(Pattern lang) !(PatternRewriteFun anl lang)
+    -- ^ Compute a replacement pattern from a match and an inspection graph.
+    -- RHS variables reuse LHS captures. See 'PatternRewriteFun'.
     | !(Rewrite anl lang) :| !(RewriteCondition anl lang)
     -- ^ Conditional Rewrite
 infix 3 :=
@@ -129,8 +137,80 @@ data MatchInfo anl lang = MatchInfo
 -- node values), not on incidental details like iteration order over sets.
 type RewriteFun anl lang = Map String (MatchInfo anl lang) -> Maybe (Fix lang)
 
+-- | Compute a replacement pattern from one match and a read-only graph.
+-- Return 'Nothing' when the available evidence does not justify the rewrite.
+-- Return 'Just' a pattern to insert and equate with the matched root. Variables
+-- in that pattern reuse the corresponding LHS captures; all must be bound on
+-- the LHS. Language payloads (such as integer constants) can be computed freely.
+--
+-- The standard runner supplies its current graph immediately before applying
+-- the match, just as for application-time 'RewriteCondition' checks. Earlier
+-- applications in the same round may have merged classes; use
+-- 'Data.Equality.Graph.find' or the canonicalizing '_class' lens when
+-- inspecting IDs from the substitution. Parent analysis and congruence may
+-- still await the end-of-round rebuild. Custom runners choose their own
+-- inspection graph via 'rewriteRhs', for example an analysis snapshot.
+--
+-- Refusal cannot mutate the graph. A successful result must be equivalent to
+-- the LHS under the proven facts: subsequent graph growth cannot undo an
+-- equality. Builders should be deterministic and idempotent for unchanged
+-- evidence. Repeatedly inventing fresh terms can exhaust the iteration limit.
+-- Refusals are not cached and may be retried as saturation continues, subject
+-- to the scheduler and the standard runner's 30-round limit.
+--
+-- For example, rewrite @(x + a) + b@ to @x + (a + b)@ when analysis proves
+-- integer values for @a@ and @b@. The builder computes their sum while keeping
+-- @x@ as a capture, without extracting or copying its expression.
+type PatternRewriteFun anl lang = VarsState -> Subst -> EGraph anl lang -> Maybe (Pattern lang)
+
+-- | The search pattern, independent of conditions or RHS construction.
+rewriteLhs :: Rewrite anl lang -> Pattern lang
+rewriteLhs (lhs := _) = lhs
+rewriteLhs (lhs :=> _) = lhs
+rewriteLhs (ComputePattern lhs _) = lhs
+rewriteLhs (rw :| _) = rewriteLhs rw
+
+-- | Evaluate conditions and construct a replacement without changing a graph.
+-- Conditions are checked from the outside in, as during application in the
+-- standard runner, and a failed condition prevents evaluation of the builder.
+-- Expression-producing 'RewriteFun' results are converted to closed patterns.
+--
+-- The variable map and substitution must come from matching 'rewriteLhs'. The
+-- supplied graph must contain those classes. An unbound RHS variable is a
+-- malformed rule, reported as an error before any RHS nodes are inserted;
+-- 'Nothing' is reserved for non-applicability.
+--
+-- Custom runners can inspect a snapshot here, then resolve the returned
+-- pattern's captures against their current graph and perform their own
+-- insertion and root merge. This keeps capture resolution and insertion under
+-- the caller's control.
+rewriteRhs :: Traversable lang
+           => Rewrite anl lang -> VarsState -> Subst -> EGraph anl lang
+           -> Maybe (Pattern lang)
+rewriteRhs rw vss subst egr = do
+    rhs <- go rw
+    check rhs `seq` pure rhs
+  where
+    go (_ := rhs) = Just rhs
+    go (_ :=> build) = cata pat <$> build (M.map lookupInfo (varNames vss))
+    go (ComputePattern _ build) = build vss subst egr
+    go (inner :| cond)
+      | cond vss subst egr = go inner
+      | otherwise = Nothing
+
+    lookupInfo var =
+      let eclass = egr ^. _class (findSubst var subst)
+      in MatchInfo (eclass ^. _data) (eclass ^. _nodes)
+
+    check (VariablePattern v) =
+      case M.lookup v (varNames vss) >>= (`lookupSubst` subst) of
+        Just _ -> ()
+        Nothing -> error $ "rewriteRhs: unbound RHS variable " <> show v
+    check (NonVariablePattern p) = foldr (seq . check) () p
+
 
 instance (∀ a. Show a => Show (lang a)) => Show (Rewrite anl lang) where
   show (rw :| _) = show rw <> " :| <cond>"
   show (lhs := rhs) = show lhs <> " := " <> show rhs
   show (lhs :=> _) = show lhs <> " :=> <fun>"
+  show (ComputePattern lhs _) = "ComputePattern (" <> show lhs <> ") <fun>"

--- a/test/ComputedRewrites.hs
+++ b/test/ComputedRewrites.hs
@@ -1,0 +1,215 @@
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+module ComputedRewrites (computedRewriteTests) where
+
+import Control.Exception (ErrorCall, evaluate, try)
+import Control.Monad (forM_, guard, void)
+import Data.List (isInfixOf)
+import qualified Data.IntMap.Strict as IM
+import qualified Data.Set as S
+
+import Data.Equality.Analysis
+import qualified Data.Equality.Graph as G
+import Data.Equality.Graph.Internal (classes, memo)
+import Data.Equality.Graph.Lens
+import qualified Data.Equality.Graph.Monad as EG
+import Data.Equality.Matching
+import Data.Equality.Matching.Database (Subst, findSubst)
+import Data.Equality.Saturation
+import Data.Equality.Saturation.Scheduler
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit
+
+data Expr a = Number Integer | Symbol String | Add a a | Neg a
+    deriving (Eq, Ord, Show, Functor, Foldable, Traversable)
+
+-- No modifyA: knowing a constant must not materialize a literal by itself.
+instance Analysis (Maybe Integer) Expr where
+    makeA = constantValue
+    joinA = joinConstant
+
+constantValue :: Expr (Maybe Integer) -> Maybe Integer
+constantValue = \case
+    Number n -> Just n
+    Symbol _ -> Nothing
+    Add a b -> (+) <$> a <*> b
+    Neg a -> negate <$> a
+
+joinConstant :: Maybe Integer -> Maybe Integer -> Maybe Integer
+joinConstant Nothing b = b
+joinConstant a Nothing = a
+joinConstant a b
+    | a == b = a
+    | otherwise = error "computed rewrite equated distinct constants"
+
+cost :: CostFunction analysis Expr Int
+cost = costOnly $ \node -> 1 + sum node
+
+number :: Integer -> Fix Expr
+number = Fix . Number
+
+valueOf :: String -> VarsState -> Subst -> G.EGraph (Maybe Integer) Expr -> Maybe Integer
+valueOf name vars subst graph =
+    graph ^. _class (findSubst (findVarName vars name) subst) . _data
+
+foldAddition :: Rewrite (Maybe Integer) Expr
+foldAddition = ComputePattern (pat $ Add "a" "b") $ \vars subst graph -> do
+    a <- valueOf "a" vars subst graph
+    b <- valueOf "b" vars subst graph
+    pure $ pat $ Number $ a + b
+
+combineConstants :: Rewrite (Maybe Integer) Expr
+combineConstants = ComputePattern (pat $ Add (pat $ Add "x" "a") "b") $ \vars subst graph -> do
+    a <- valueOf "a" vars subst graph
+    b <- valueOf "b" vars subst graph
+    pure $ pat $ Add "x" (pat $ Number $ a + b)
+
+foldNegation :: PatternRewriteFun (Maybe Integer) Expr
+foldNegation vars subst graph =
+    pat . Number . negate <$> valueOf "x" vars subst graph
+
+defineX :: Rewrite analysis Expr
+defineX = pat (Symbol "x") := pat (Number 2)
+
+unknownSum :: Fix Expr
+unknownSum = Fix $ Add (Fix $ Symbol "x") (number 3)
+
+computedRewriteTests :: TestTree
+computedRewriteTests = testGroup "Computed rewrites"
+    [ testCase "materializes a literal from analysis without modifyA" $ do
+        let input = Fix $ Add (number 2) (number 3)
+            unchanged = equalitySaturation input ([] :: [Rewrite (Maybe Integer) Expr]) cost
+            rewritten = equalitySaturation input [foldAddition] cost
+        fst unchanged @?= input
+        fst rewritten @?= number 5
+        G.lookupNM (G.Node $ Number 5) (memo $ snd unchanged) @?= Nothing
+
+    , testCase "combines constants while preserving an unknown compound capture" $ do
+        let captured = Fix $ Neg $ Fix $ Symbol "x"
+            input = Fix $ Add (Fix $ Add captured (number 2)) (number 3)
+            expected = Fix $ Add captured (number 5)
+            (best, graph) = equalitySaturation input [combineConstants] cost
+            matchedClasses expression =
+                map (\match -> G.find (matchClassId match) graph) $
+                    ematch (eGraphToDatabase graph) (fst $ compileToQuery $ cata pat expression)
+            originalClasses = matchedClasses input
+        best @?= expected
+        assertBool "the source expression is retained" $ not $ null originalClasses
+        assertBool "the replacement is equivalent to the source" $
+            any (`elem` originalClasses) (matchedClasses expected)
+
+    , testCase "refuses to combine when either constant is unknown" $ do
+        let captured = Fix $ Neg $ Fix $ Symbol "x"
+            unknown = Fix $ Symbol "unknown"
+        forM_ [(unknown, number 3), (number 2, unknown)] $ \(a, b) -> do
+            let input = Fix $ Add (Fix $ Add captured a) b
+                (_, before) = EG.egraph $ EG.represent input <* EG.rebuild
+                matches = ematch (eGraphToDatabase before) $
+                    fst $ compileToQuery $ rewriteLhs combineConstants
+                (best, after) = equalitySaturation input [combineConstants] cost
+            assertBool "the LHS matches before the builder refuses" $ not $ null matches
+            best @?= input
+            G.unNodeMap (memo after) @?= G.unNodeMap (memo before)
+            classContents after @?= classContents before
+
+    , testCase "reuses nested captures after an earlier rule merges their classes" $ do
+        let ((root, oldX, two), graph) = EG.egraph $ do
+                existingTwo <- EG.represent $ number 2
+                -- Give 2 more parents than x so x's captured ID is subsumed.
+                void $ EG.represent $ Fix $ Neg $ number 2
+                void $ EG.represent $ Fix $ Add (number 2) (number 7)
+                capturedX <- EG.represent $ Fix $ Symbol "x"
+                original <- EG.represent $ Fix $ Neg unknownSum
+                runEqualitySaturation defaultBackoffScheduler [defineX, distributeNegation]
+                pure (original, capturedX, existingTwo)
+            expected = Fix $ Add (Fix $ Neg $ number 2) (number (-3))
+            (expectedClass, withExpected) = G.represent expected graph
+        assertBool "the original capture ID was merged away" $ G.find oldX graph /= oldX
+        G.find oldX graph @?= G.find two graph
+        G.find expectedClass withExpected @?= G.find root withExpected
+
+    , testCase "a computed variable RHS merges with the captured class" $ do
+        let rule = ComputePattern (pat $ Neg $ pat $ Neg "x") $ \_ _ _ -> Just "x"
+            input = Fix $ Neg $ Fix $ Neg $ Fix $ Symbol "x"
+        fst (equalitySaturation input [rule :: Rewrite (Maybe Integer) Expr] cost)
+            @?= Fix (Symbol "x")
+
+    , testCase "refusals and nested guards leave the graph unchanged" $ do
+        let (_, graph) = EG.egraph $ EG.represent unknownSum <* EG.rebuild
+            lhs = pat $ Add "a" "b"
+            rules =
+                [ foldAddition
+                , ComputePattern lhs (\_ _ _ -> Nothing)
+                , ComputePattern lhs (\_ _ _ -> error "a rejected builder was evaluated")
+                    :| (\_ _ _ -> False) :| (\_ _ _ -> True)
+                ]
+        forM_ rules $ \rule -> do
+            let (_, after) = EG.runEGraphM graph $
+                    runEqualitySaturation defaultBackoffScheduler [rule]
+            G.unNodeMap (memo after) @?= G.unNodeMap (memo graph)
+            classContents after @?= classContents graph
+
+    , testCase "reports an unbound variable in a computed RHS" $ do
+        let rule = ComputePattern (pat $ Number 1) $ \_ _ _ ->
+                Just $ pat $ Add (pat $ Number 99) "unbound"
+            result = equalitySaturation (number 1) [rule :: Rewrite (Maybe Integer) Expr] cost
+        failure <- try (evaluate $ fst result) :: IO (Either ErrorCall (Fix Expr))
+        case failure of
+            Left err -> assertBool (show err) $
+                "unbound RHS variable \"unbound\"" `isInfixOf` show err
+            Right expression -> assertFailure $ "accepted malformed RHS: " <> show expression
+
+    , testCase "retries a refused builder after an ordinary rewrite supplies facts" $
+        fst (equalitySaturation (Fix $ Neg unknownSum)
+            [ComputePattern (pat $ Neg "x") foldNegation, defineX] cost) @?= number (-5)
+
+    , testCase "retries computed rules after scheduler backoff" $
+        fst (equalitySaturation' (BackoffScheduler 0 10) (Fix $ Neg unknownSum)
+            [ComputePattern (pat $ Neg "x") foldNegation, defineX] cost) @?= number (-5)
+
+    , testCase "retries after analysis changes with unchanged node and class counts" $ do
+        let input = Fix $ Neg unknownSum
+            (root, before) = EG.egraph $ EG.represent input <* EG.rebuild
+            (_, produced) = EG.runEGraphM before $
+                runEqualitySaturation defaultBackoffScheduler [defineX :: Rewrite PrunedConstant Expr]
+            negateKnown = ComputePattern (pat $ Neg "x") $ \vars subst graph -> do
+                let PrunedConstant value = graph ^.
+                        _class (findSubst (findVarName vars "x") subst) . _data
+                pat . Number . negate <$> value
+            result = equalitySaturation input [negateKnown, defineX :: Rewrite PrunedConstant Expr] cost
+        G.sizeNM (memo produced) @?= G.sizeNM (memo before)
+        IM.size (classes produced) @?= IM.size (classes before)
+        produced ^. _class root . _data @?= PrunedConstant (Just (-5))
+        G.lookupNM (G.Node $ Number (-5)) (memo produced) @?= Nothing
+        fst result @?= number (-5)
+    ]
+  where
+    distributeNegation = ComputePattern (pat $ Neg $ pat $ Add "x" "offset") $ \vars subst graph -> do
+        x <- valueOf "x" vars subst graph
+        guard $ x == 2
+        offset <- valueOf "offset" vars subst graph
+        pure $ pat $ Add (pat $ Neg "x") (pat $ Number $ negate offset)
+
+    classContents = IM.map (\cl -> (G.eClassNodes cl, G.eClassData cl)) . classes
+
+-- Pruning a redundant expression after its equivalent literal appears is an
+-- idempotent analysis hook. Replacing Symbol x with Number 2 keeps both counts
+-- unchanged while learning a value; parent facts become available at rebuild.
+newtype PrunedConstant = PrunedConstant (Maybe Integer)
+    deriving (Eq, Show)
+
+instance Analysis PrunedConstant Expr where
+    makeA = PrunedConstant . constantValue . fmap (\(PrunedConstant value) -> value)
+    joinA (PrunedConstant a) (PrunedConstant b) = PrunedConstant $ joinConstant a b
+    modifyA classId graph = case graph ^. _class classId . _data of
+        PrunedConstant (Just n)
+            | let literal = G.Node $ Number n
+            , let nodes = graph ^. _class classId . _nodes
+            , S.member literal nodes ->
+                let removed = S.delete literal nodes
+                    pruned = over (_class classId . _nodes) (const $ S.singleton literal) graph
+                in over _memo (\nodeMap -> S.foldr G.deleteNM nodeMap removed) pruned
+        _ -> graph

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -12,6 +12,7 @@ import Sym
 import Lambda
 import SimpleSym
 import T32
+import ComputedRewrites
 
 import qualified Computed
 import qualified T1
@@ -36,6 +37,7 @@ tests =testGroup "Tests"
     , testCase "T2" (T2.main `catch` (\(e :: SomeException) -> assertFailure (show e)))
     , testCase "T3" (T3.main `catch` (\(e :: SomeException) -> assertFailure (show e)))
     , testT32
+    , computedRewriteTests
 # ifdef VIZDOT
       , testCase "e-graph visualization" VizDot.visualizeSaturatedEGraph
 # endif


### PR DESCRIPTION
Computed rewrites currently return `Fix l`, which cannot refer back to captured e-classes. Add `ComputePattern lhs build`: a pure builder reads the match and an inspection graph, then returns an optional `Pattern l` whose variables reuse the LHS captures. The existing `:=>`, `RewriteFun`, and `MatchInfo` APIs remain compatible.

`rewriteLhs` and `rewriteRhs` let custom runners select their inspection graph and control insertion. Static and computed replacements share insertion; refusal does not mutate the graph, and unbound RHS variables are diagnosed before insertion. Fixed-point detection also observes class nodes and analysis, so count-stable changes can enable another round under the existing scheduler policy.

The example combines known integer constants: `(x + 2) + 3` becomes `x + 5`, preserving the captured expression `x` without knowing its value. It refuses when either constant is unknown. This uses the small expression language already present in the computed-rewrite contract tests.

Validation on GHC 9.12.2:

- Full `hegg-test` suite: all 52 tests pass, including the existing expression-producing computed rewrite and scheduler tests.
- Full suite with `+vizdot`: all 53 tests pass.
- `cabal check` and Haddock generation.
